### PR TITLE
[BU-173, #44] feat: 범용 Input 컴포넌트 구현

### DIFF
--- a/src/components/ui/input.stories.tsx
+++ b/src/components/ui/input.stories.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { SearchOutlined } from "@ant-design/icons";
+
+import { Input, type InputProps } from "./input";
+
+const meta: Meta<InputProps> = {
+  title: "Components/UI/Input",
+  component: Input,
+  tags: ["autodocs"],
+  args: {
+    label: "현장명",
+    placeholder: "예) 이천 A 아파트 현장",
+    description: "시설명이나 프로젝트 명칭을 입력하세요",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<InputProps>;
+
+export const Default: Story = {};
+
+export const WithPrefix: Story = {
+  args: {
+    prefix: <SearchOutlined />,
+    placeholder: "검색어 입력",
+  },
+};
+
+export const Error: Story = {
+  args: {
+    label: "담당자 이메일",
+    placeholder: "name@company.com",
+    error: "유효한 이메일 주소를 입력해 주세요",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: "프로젝트 코드",
+    value: "BUP-2024-1105",
+    disabled: true,
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    size: "sm",
+    label: "직원 수",
+    placeholder: "0",
+    suffix: "명",
+  },
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
+
+import { cn } from "@/utils/cn";
+
+const variantClasses = {
+  default:
+    "border-border hover:border-brand-primary focus-within:border-brand-primary focus-within:ring-2 focus-within:ring-brand-primary/20 dark:border-dark-border dark:hover:border-brand-primary/70",
+  error:
+    "border-state-danger focus-within:border-state-danger focus-within:ring-2 focus-within:ring-state-danger/20 text-state-danger",
+  subtle:
+    "border-transparent bg-bg-subtle hover:border-border focus-within:border-brand-primary focus-within:ring-2 focus-within:ring-brand-primary/15 dark:bg-dark-bg-surface/60",
+};
+
+const sizeClasses = {
+  sm: "h-9 text-sm",
+  md: "h-11 text-sm sm:text-base",
+  lg: "h-12 text-base",
+};
+
+export interface InputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "prefix" | "suffix"> {
+  label?: string;
+  description?: string;
+  error?: string;
+  prefix?: ReactNode;
+  suffix?: ReactNode;
+  size?: keyof typeof sizeClasses;
+  variant?: keyof typeof variantClasses;
+  fullWidth?: boolean;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      className,
+      label,
+      description,
+      error,
+      prefix,
+      suffix,
+      size = "md",
+      variant = "default",
+      fullWidth = true,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
+    const hasError = Boolean(error);
+    const variantClass =
+      variant === "default" && hasError ? variantClasses.error : variantClasses[variant];
+
+    return (
+      <label
+        className={cn(
+          "flex w-full flex-col gap-1 text-text-strong dark:text-dark-text-strong",
+          fullWidth ? "w-full" : "w-max",
+        )}
+      >
+        {label ? (
+          <span className="text-sm font-medium text-text-strong dark:text-dark-text-strong">
+            {label}
+          </span>
+        ) : null}
+        <div
+          className={cn(
+            "flex items-center gap-2 rounded-lg border bg-bg-surface px-3 transition-all dark:bg-dark-bg-surface",
+            variantClass,
+            disabled && "opacity-60 cursor-not-allowed",
+          )}
+        >
+          {prefix ? (
+            <span className="text-text-subtle dark:text-dark-text-base">{prefix}</span>
+          ) : null}
+          <input
+            ref={ref}
+            className={cn(
+              "flex-1 bg-transparent text-text-base placeholder:text-text-subtle outline-none dark:text-dark-text-base dark:placeholder:text-dark-text-base/70",
+              sizeClasses[size],
+              className,
+            )}
+            disabled={disabled}
+            {...props}
+          />
+          {suffix ? (
+            <span className="text-text-subtle dark:text-dark-text-base">{suffix}</span>
+          ) : null}
+        </div>
+        {hasError ? (
+          <span className="text-sm text-state-danger">{error}</span>
+        ) : description ? (
+          <span className="text-sm text-text-subtle dark:text-dark-text-base">{description}</span>
+        ) : null}
+      </label>
+    );
+  },
+);
+
+Input.displayName = "Input";


### PR DESCRIPTION
## 🎯 변경 사항

Figma Company/SiteManager 섹션 기반으로 범용 Input 컴포넌트를 src/components/ui/input.tsx에 구현했습니다.
label, description, error 메시지, prefix/suffix, size(sm/md/lg), variant(default/error/subtle), fullWidth, disabled 등 다양한 옵션 지원.
Tailwind v4 토큰과 다크모드/포커스 상태를 공유.
cn 유틸을 사용해 조건부 클래스를 일원화했습니다.
Storybook에 Input 스토리(default, with prefix, error, disabled, compact)를 추가해 시각적으로 검증할 수 있습니다.
샘플 페이지 src/app/page.tsx에는 임시 Input 데모는 제거돼 있습니다(Storybook에서 확인).

## 📝 사용 방법

yarn install (필요 시 최신 devDependencies 적용)
yarn storybook → http://localhost:6006에서 Input 스토리 확인
실제 화면에서 Input을 사용하려면 import { Input } from "@/components/ui/input"; 후 label/prefix/error 등 props 전달

## ✅ 테스트

[x] yarn dev로 페이지 빌드 확인
[x] yarn storybook 실행으로 variant별 상태 검증

## 🔗 관련 이슈

- Jira: resolves BU-173
- resolves #44 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 새로운 Input 컴포넌트 추가 - 라벨, 설명, 에러 상태, 접두사/접미사 아이콘 지원
  * 다양한 크기(소, 중, 대)와 스타일 옵션(기본, 에러, 서브틀) 제공
  * 비활성화 및 전체 너비 레이아웃 옵션 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->