### PR TITLE
[BU-174, #46] feat: 범용 상태배지 컴포넌트 제작

### DIFF
--- a/src/components/ui/status-pill.stories.tsx
+++ b/src/components/ui/status-pill.stories.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { CheckOutlined, CloseCircleOutlined } from "@ant-design/icons";
+
+import { StatusPill, type StatusPillProps } from "./status-pill";
+
+const meta: Meta<StatusPillProps> = {
+  title: "Components/UI/StatusPill",
+  component: StatusPill,
+  tags: ["autodocs"],
+  args: {
+    children: "지급",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<StatusPillProps>;
+
+export const Success: Story = {
+  args: {
+    variant: "success",
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    variant: "danger",
+    children: "미지급",
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: "warning",
+    children: "지각",
+  },
+};
+
+export const InfoWithIcon: Story = {
+  args: {
+    variant: "info",
+    children: "근무 중",
+    icon: <CheckOutlined />,
+    dot: false,
+  },
+};
+
+export const NeutralCompact: Story = {
+  args: {
+    variant: "neutral",
+    children: "대기",
+    size: "sm",
+  },
+};
+
+export const DangerWithIcon: Story = {
+  args: {
+    variant: "danger",
+    children: "경고",
+    icon: <CloseCircleOutlined />,
+    dot: false,
+  },
+};

--- a/src/components/ui/status-pill.tsx
+++ b/src/components/ui/status-pill.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { forwardRef, type HTMLAttributes, type ReactNode } from "react";
+
+import { cn } from "@/utils/cn";
+
+const variantClasses = {
+  success:
+    "bg-state-success/10 text-state-success border border-state-success/20 dark:bg-state-success/20 dark:text-state-success dark:border-state-success/30",
+  danger:
+    "bg-state-danger/10 text-state-danger border border-state-danger/20 dark:bg-state-danger/20 dark:text-state-danger dark:border-state-danger/30",
+  warning:
+    "bg-state-warning/15 text-state-warning border border-state-warning/20 dark:bg-state-warning/20 dark:text-state-warning",
+  info: "bg-brand-secondary/10 text-brand-secondary border border-brand-secondary/20 dark:bg-brand-secondary/20 dark:text-brand-secondary",
+  neutral:
+    "bg-bg-subtle text-text-strong border border-border dark:bg-dark-bg-surface dark:text-dark-text-strong dark:border-dark-border",
+};
+
+const dotClasses = {
+  success: "bg-state-success",
+  danger: "bg-state-danger",
+  warning: "bg-state-warning",
+  info: "bg-brand-secondary",
+  neutral: "bg-text-base dark:bg-dark-text-base",
+};
+
+type StatusVariant = keyof typeof variantClasses;
+
+export interface StatusPillProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: StatusVariant;
+  size?: "sm" | "md";
+  icon?: ReactNode;
+  dot?: boolean;
+}
+
+export const StatusPill = forwardRef<HTMLSpanElement, StatusPillProps>(
+  ({ className, variant = "info", size = "md", dot = true, icon, children, ...props }, ref) => {
+    const dotSize = size === "sm" ? "w-1.5 h-1.5" : "w-2 h-2";
+
+    return (
+      <span
+        ref={ref}
+        className={cn(
+          "inline-flex items-center gap-2 rounded-full px-3 font-medium transition-colors",
+          size === "sm" ? "py-1 text-xs" : "py-1.5 text-sm",
+          variantClasses[variant],
+          className,
+        )}
+        {...props}
+      >
+        {icon ? (
+          <span className="flex items-center text-current">{icon}</span>
+        ) : (
+          dot && <span className={cn("rounded-full", dotSize, dotClasses[variant])} />
+        )}
+        <span>{children}</span>
+      </span>
+    );
+  },
+);
+
+StatusPill.displayName = "StatusPill";


### PR DESCRIPTION
## 🎯 변경 사항

Figma Company/SiteManager 상태 라벨을 기반으로 StatusPill 컴포넌트를 새로 구현했습니다.
상태(success, warning, danger, info, neutral), 사이즈(sm, md), dot/아이콘 표시를 props로 제어
Tailwind v4 토큰과 다크모드 배경·텍스트 색상을 공유
cn 유틸을 사용해 클래스 병합
Storybook(StatusPill.stories.tsx)에 상태별·아이콘 여부·compact 예제를 추가해 시각적으로 검증할 수 있습니다.

## 📝 사용 방법

```typescript
import { StatusPill } from "@/components/ui/status-pill";

<StatusPill variant="success">지급</StatusPill>
<StatusPill variant="danger" icon={<CloseCircleOutlined />} dot={false}>
  경고
</StatusPill>
```

## ✅ 테스트

- [x] yarn storybook (상태별 케이스 확인)
- [x] yarn dev 빌드 확인
- [x] 다크 모드와 라이트 모드에서 색상 대비 확인

## 🔗 관련 이슈

- Jira: resolves BU-174
- resolves #46 
