### PR TITLE
[BU-189, #56] feat: 현장 관리자용 회원가입 구현

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { SiteManagerSignupForm } from "@/components/features/auth/signup-form";
+import { LoginShell } from "@/components/features/auth/login-shell";
+
+const brandContent = {
+  badge: "SITE MANAGER",
+  title: "",
+  description: "",
+  tone: "primary" as const,
+  image: {
+    src: "/architecture.jpg",
+    alt: "Signup background image",
+  },
+};
+
+export default function SiteManagerSignupPage() {
+  return (
+    <LoginShell brand={brandContent} imagePosition="right">
+      <SiteManagerSignupForm />
+    </LoginShell>
+  );
+}

--- a/src/components/features/auth/login-shell.tsx
+++ b/src/components/features/auth/login-shell.tsx
@@ -22,9 +22,10 @@ type LoginShellProps = {
     tone?: "primary" | "secondary";
   };
   children: ReactNode;
+  imagePosition?: "left" | "right";
 };
 
-export function LoginShell({ brand, children }: LoginShellProps) {
+export function LoginShell({ brand, children, imagePosition = "left" }: LoginShellProps) {
   const tone = brand.tone ?? "primary";
 
   const asideBackgroundClass =
@@ -37,38 +38,43 @@ export function LoginShell({ brand, children }: LoginShellProps) {
       ? "bg-gradient-to-br from-brand-secondary/80 via-brand-secondary/70 to-brand-primary/60"
       : "bg-gradient-to-br from-brand-primary/70 via-brand-primary/60 to-brand-secondary/50";
 
+  const aside = (
+    <aside
+      className={cn(
+        "relative hidden w-[45%] overflow-hidden border-border p-12 dark:border-dark-border lg:flex",
+        imagePosition === "left" ? "border-r" : "border-l",
+        asideBackgroundClass,
+      )}
+    >
+      <div className="relative z-10 flex flex-col gap-4 text-white/80">
+        <div className="mt-auto inline-flex flex-col gap-1 text-sm text-white/80">
+          <span>도움이 필요하신가요?</span>
+          <Link href="/support" className="text-white underline-offset-4 hover:underline">
+            고객 지원팀에 문의하기 →
+          </Link>
+        </div>
+      </div>
+      <div className="absolute inset-0">
+        <Image
+          src={brand.image.src}
+          alt={brand.image.alt}
+          priority
+          fill
+          sizes="(min-width: 1024px) 45vw, 100vw"
+          className="object-cover"
+        />
+        <div className={cn("absolute inset-0", overlayGradientClass)} />
+      </div>
+    </aside>
+  );
+
   return (
     <div className="flex min-h-screen w-full bg-white text-text-base dark:bg-dark-bg-page dark:text-dark-text-base">
-      <aside
-        className={cn(
-          "relative hidden w-[45%] overflow-hidden border-r border-border p-12 dark:border-dark-border lg:flex",
-          asideBackgroundClass,
-        )}
-      >
-        <div className="relative z-10 flex flex-col gap-4 text-white/80">
-          <div className="mt-auto inline-flex flex-col gap-1 text-sm text-white/80">
-            <span>도움이 필요하신가요?</span>
-            <Link href="/support" className="text-white underline-offset-4 hover:underline">
-              고객 지원팀에 문의하기 →
-            </Link>
-          </div>
-        </div>
-        <div className="absolute inset-0">
-          <Image
-            src={brand.image.src}
-            alt={brand.image.alt}
-            priority
-            fill
-            sizes="(min-width: 1024px) 45vw, 100vw"
-            className="object-cover"
-          />
-          <div className={cn("absolute inset-0", overlayGradientClass)} />
-        </div>
-      </aside>
-
+      {imagePosition === "left" ? aside : null}
       <section className="flex w-full items-center justify-center bg-white px-6 py-12 dark:bg-dark-bg-page sm:px-10 lg:w-[55%]">
         <div className="w-full max-w-[460px]">{children}</div>
       </section>
+      {imagePosition === "right" ? aside : null}
     </div>
   );
 }

--- a/src/components/features/auth/signup-form.tsx
+++ b/src/components/features/auth/signup-form.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/Button/button";
+import { Input } from "@/components/ui/Input/input";
+
+export function SiteManagerSignupForm() {
+  const [name, setName] = useState("");
+  const [userId, setUserId] = useState("");
+  const [password, setPassword] = useState("");
+  const [secretKey, setSecretKey] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [idStatusMessage, setIdStatusMessage] = useState<string | null>(null);
+  const [idStatus, setIdStatus] = useState<"idle" | "error" | "success">("idle");
+
+  const handleDuplicateCheck = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    // TODO: 실제 중복 확인 API 연동
+    setIdStatus("error");
+    setIdStatusMessage("이미 존재하는 ID입니다.");
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // TODO: 회원가입 API 연동
+  };
+
+  const isDisabled =
+    !name || !userId || !password || !secretKey || !phoneNumber || password.length < 8;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-8 text-text-strong dark:text-dark-text-strong">
+      <header className="space-y-3">
+        <h1 className="text-3xl !font-bold">회원가입</h1>
+        <p className="text-sm text-text-subtle dark:text-dark-text-base">
+          Build-Up 현장 관리자 계정을 생성하고 현장 데이터를 효율적으로 관리하세요.
+        </p>
+      </header>
+
+      <div className="space-y-5">
+        <Input
+          label="성함"
+          placeholder="이름을 입력해주세요"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-text-strong dark:text-dark-text-strong">ID</p>
+          <div className="flex flex-col gap-3 sm:grid sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start sm:gap-4">
+            <Input
+              placeholder="아이디를 입력해주세요"
+              value={userId}
+              onChange={(e) => {
+                setUserId(e.target.value);
+                setIdStatus("idle");
+                setIdStatusMessage(null);
+              }}
+              variant={idStatus === "error" ? "error" : "default"}
+              required
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-12 rounded-xl border border-brand-primary px-6 text-brand-primary sm:self-start"
+              onClick={handleDuplicateCheck}
+            >
+              중복 확인
+            </Button>
+          </div>
+          {idStatus === "error" ? (
+            <p className="text-sm text-state-danger">{idStatusMessage}</p>
+          ) : idStatus === "success" ? (
+            <p className="text-sm text-brand-primary">사용 가능한 ID입니다.</p>
+          ) : null}
+        </div>
+
+        <Input
+          label="PW"
+          placeholder="비밀번호를 입력해주세요"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+
+        <Input
+          label="Secret Key"
+          placeholder="시크릿 키를 입력해주세요"
+          value={secretKey}
+          onChange={(e) => setSecretKey(e.target.value)}
+          required
+        />
+
+        <Input
+          label="전화번호"
+          placeholder="전화번호를 입력해주세요"
+          type="tel"
+          value={phoneNumber}
+          onChange={(e) => setPhoneNumber(e.target.value)}
+          required
+        />
+      </div>
+
+      <div className="space-y-4">
+        <Button
+          type="submit"
+          size="lg"
+          className="h-12 w-full rounded-xl bg-brand-primary text-white hover:bg-brand-primary-strong"
+          disabled={isDisabled}
+        >
+          확인
+        </Button>
+        <p className="!mt-2 text-center text-sm text-text-subtle dark:text-dark-text-base">
+          이미 계정이 있으신가요?{" "}
+          <Link href="/login/site-manager" className="font-semibold text-brand-primary">
+            로그인
+          </Link>
+        </p>
+      </div>
+    </form>
+  );
+}
+1;

--- a/src/components/features/auth/signup-form.tsx
+++ b/src/components/features/auth/signup-form.tsx
@@ -1,34 +1,106 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
+
+import { notification } from "antd";
+import { useMutation } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/Button/button";
 import { Input } from "@/components/ui/Input/input";
+import { checkUserId } from "@/lib/api/check-user-id";
+import { registerManager } from "@/lib/api/register-manager";
 
 export function SiteManagerSignupForm() {
+  const router = useRouter();
   const [name, setName] = useState("");
   const [userId, setUserId] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [secretKey, setSecretKey] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
   const [idStatusMessage, setIdStatusMessage] = useState<string | null>(null);
   const [idStatus, setIdStatus] = useState<"idle" | "error" | "success">("idle");
+  const [formMessage, setFormMessage] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const duplicateMutation = useMutation({
+    mutationFn: checkUserId,
+    onSuccess: (exists) => {
+      if (exists) {
+        setIdStatus("error");
+        setIdStatusMessage("이미 존재하는 ID입니다.");
+      } else {
+        setIdStatus("success");
+        setIdStatusMessage("사용 가능한 ID입니다.");
+      }
+    },
+    onError: (error: Error) => {
+      setIdStatus("error");
+      setIdStatusMessage(error.message);
+    },
+  });
+
+  const registerMutation = useMutation({
+    mutationFn: registerManager,
+    onSuccess: () => {
+      setFormError(null);
+      setFormMessage("회원가입 신청이 완료되었습니다. 승인 안내를 확인해주세요.");
+      notification.success({
+        message: "회원가입이 완료되었습니다.",
+        placement: "topRight",
+        duration: 2,
+      });
+      setTimeout(() => {
+        router.push("/login/site-manager");
+      }, 300);
+    },
+    onError: (error: Error) => {
+      setFormMessage(null);
+      setFormError(error.message);
+      notification.error({
+        message: error.message,
+        placement: "topRight",
+        duration: 2,
+      });
+    },
+  });
 
   const handleDuplicateCheck = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    // TODO: 실제 중복 확인 API 연동
-    setIdStatus("error");
-    setIdStatusMessage("이미 존재하는 ID입니다.");
+    if (!userId) {
+      setIdStatus("error");
+      setIdStatusMessage("아이디를 입력한 뒤 중복 확인을 진행해주세요.");
+      return;
+    }
+    duplicateMutation.mutate(userId);
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    // TODO: 회원가입 API 연동
+    setFormError(null);
+    setFormMessage(null);
+    registerMutation.mutate({
+      managerName: name,
+      userId,
+      password,
+      confirmPassword,
+      secretKey,
+      phone: phoneNumber,
+      passwordMatching: password === confirmPassword,
+    });
   };
 
   const isDisabled =
-    !name || !userId || !password || !secretKey || !phoneNumber || password.length < 8;
+    !name ||
+    !userId ||
+    !password ||
+    !confirmPassword ||
+    !secretKey ||
+    !phoneNumber ||
+    password.length < 8 ||
+    password !== confirmPassword;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8 text-text-strong dark:text-dark-text-strong">
@@ -67,8 +139,9 @@ export function SiteManagerSignupForm() {
               variant="ghost"
               className="h-12 rounded-xl border border-brand-primary px-6 text-brand-primary sm:self-start"
               onClick={handleDuplicateCheck}
+              disabled={duplicateMutation.isPending}
             >
-              중복 확인
+              {duplicateMutation.isPending ? "확인 중..." : "중복 확인"}
             </Button>
           </div>
           {idStatus === "error" ? (
@@ -88,6 +161,20 @@ export function SiteManagerSignupForm() {
         />
 
         <Input
+          label="비밀번호 확인"
+          placeholder="비밀번호를 다시 입력해주세요"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          error={
+            confirmPassword && confirmPassword !== password
+              ? "비밀번호가 일치하지 않습니다."
+              : undefined
+          }
+        />
+
+        <Input
           label="Secret Key"
           placeholder="시크릿 키를 입력해주세요"
           value={secretKey}
@@ -103,6 +190,11 @@ export function SiteManagerSignupForm() {
           onChange={(e) => setPhoneNumber(e.target.value)}
           required
         />
+        {formError ? (
+          <p className="text-sm font-semibold text-state-danger">{formError}</p>
+        ) : formMessage ? (
+          <p className="text-sm font-semibold text-brand-primary">{formMessage}</p>
+        ) : null}
       </div>
 
       <div className="space-y-4">
@@ -110,9 +202,9 @@ export function SiteManagerSignupForm() {
           type="submit"
           size="lg"
           className="h-12 w-full rounded-xl bg-brand-primary text-white hover:bg-brand-primary-strong"
-          disabled={isDisabled}
+          disabled={isDisabled || registerMutation.isPending}
         >
-          확인
+          {registerMutation.isPending ? "진행 중..." : "확인"}
         </Button>
         <p className="!mt-2 text-center text-sm text-text-subtle dark:text-dark-text-base">
           이미 계정이 있으신가요?{" "}
@@ -124,4 +216,3 @@ export function SiteManagerSignupForm() {
     </form>
   );
 }
-1;

--- a/src/lib/api/check-user-id.ts
+++ b/src/lib/api/check-user-id.ts
@@ -1,0 +1,26 @@
+export type CheckUserIdResponse = {
+  success: boolean;
+  message: string;
+  code: string;
+  data: {
+    exists: boolean;
+  };
+};
+
+export async function checkUserId(userId: string) {
+  const response = await fetch(`/api/v1/auth/exists?userId=${encodeURIComponent(userId)}`, {
+    method: "GET",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("아이디 중복 확인 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as CheckUserIdResponse;
+  if (!json.success) {
+    throw new Error(json.message || "아이디 중복 확인 중 오류가 발생했습니다.");
+  }
+
+  return json.data.exists;
+}

--- a/src/lib/api/register-manager.ts
+++ b/src/lib/api/register-manager.ts
@@ -1,0 +1,39 @@
+export type RegisterManagerPayload = {
+  managerName: string;
+  userId: string;
+  password: string;
+  confirmPassword: string;
+  secretKey: string;
+  phone: string;
+  passwordMatching: boolean;
+};
+
+export type RegisterManagerResponse = {
+  success: boolean;
+  message: string;
+  code: string;
+  data: unknown;
+};
+
+export async function registerManager(payload: RegisterManagerPayload) {
+  const response = await fetch("/api/v1/auth/register/manager", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error("회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+  }
+
+  const json = (await response.json()) as RegisterManagerResponse;
+
+  if (!json.success) {
+    throw new Error(json.message || "회원가입 중 오류가 발생했습니다.");
+  }
+
+  return json.data;
+}


### PR DESCRIPTION
## 🎯 변경 사항

/signup에 현장관리자용 회원가입 UI 구현
- Figma 맞춤 레이아웃, 라벨/헬퍼/에러 상태, 중복확인 버튼 정렬
- Input, Button, LoginShell 재사용

API 연동
- GET /v1/auth/exists → checkUserId
- POST /v1/auth/register/manager → registerManager
- 성공/실패 시 antd notification 우측 상단 노출, 성공 후 /login/site-manager 이동

폼 상태/검증
- 비밀번호 확인, Secret Key/전화번호 필수, 상태 메시지 및 토스트 출력
- 진행 중 버튼 비활성화 및 로딩 문구 표시

## 📝 사용 방법

yarn dev 실행 후 http://localhost:3000/signup 접속
필수 값 입력 → “중복 확인” 클릭으로 ID 사용 가능 여부 확인
비밀번호/확인 일치 및 Secret Key, 전화번호 입력 후 “확인” 제출
성공 시 우측 상단 토스트 확인 후 /login/site-manager로 이동

## ✅ 테스트

- [x] ID 미입력 상태에서 중복확인 시 에러 문구 노출
- [x] 중복확인 성공/실패 토스트 노출
- [x] 비밀번호 불일치 시 에러 메시지
- [x] 회원가입 성공 후 /login/site-manager 이동 및 토스트 유지

## 🔗 관련 이슈

- Jira: resolves BU-189
- resolves #56 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 사이트 매니저 회원가입 페이지 추가
  * 회원가입 폼에 사용자 ID 중복 확인 기능 제공
  * 이름, ID, 비밀번호, 시크릿 키, 전화번호 입력 필드 포함
  * 폼 레이아웃에서 이미지 위치 선택 옵션 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->