### PR TITLE
[BU-192, #61] Cache attendance data with tanstack query

### DIFF
--- a/src/app/(company)/company/[siteId]/attendance/page.tsx
+++ b/src/app/(company)/company/[siteId]/attendance/page.tsx
@@ -12,68 +12,16 @@ import {
   SegmentedToggle,
   type SegmentedToggleOption,
 } from "@/components/common/toggles/segmented-toggle";
-import { Table } from "@/components/ui/Table/table";
-import { cn } from "@/utils/cn";
 import { buildCompanyNavItems } from "@/constants/company-nav";
 import { useCompanySites } from "@/hooks/use-company-sites";
-
-type AttendanceStatus = "normal" | "late" | "earlyLeave" | "absent";
-
-type AttendanceRecord = {
-  id: string;
-  name: string;
-  ssnMasked: string;
-  status: AttendanceStatus;
-  clockIn?: string;
-  clockOut?: string;
-  totalHours?: string;
-  overtimeSummary?: string;
-};
-
-const regularAttendanceRecords: AttendanceRecord[] = [
-  {
-    id: "r1",
-    name: "김철수",
-    ssnMasked: "850101-1******",
-    status: "normal",
-    clockIn: "08:00",
-    clockOut: "18:00",
-    totalHours: "8시간",
-    overtimeSummary: "2시간 / - / -",
-  },
-  {
-    id: "r2",
-    name: "박영희",
-    ssnMasked: "920315-2******",
-    status: "late",
-    clockIn: "08:30",
-    clockOut: "18:00",
-    totalHours: "7.5시간",
-    overtimeSummary: "1.5시간 / 1시간 / -",
-  },
-  {
-    id: "r3",
-    name: "이민수",
-    ssnMasked: "880722-1******",
-    status: "normal",
-    clockIn: "07:55",
-    clockOut: "18:30",
-    totalHours: "8.5시간",
-    overtimeSummary: "2.5시간 / - / -",
-  },
-  {
-    id: "r4",
-    name: "최정훈",
-    ssnMasked: "750908-1******",
-    status: "absent",
-    clockIn: "-",
-    clockOut: "-",
-    totalHours: "-",
-    overtimeSummary: "-",
-  },
-];
-
-const dailyAttendanceRecords: AttendanceRecord[] = regularAttendanceRecords;
+import { useAttendanceRecords } from "@/hooks/use-attendance-records";
+import { Table } from "@/components/ui/Table/table";
+import { cn } from "@/utils/cn";
+import type {
+  AttendanceRecord,
+  AttendanceStatus,
+  EmploymentType,
+} from "@/lib/api/get-attendance";
 
 const yearOptions = Array.from({ length: 3 }).map((_, index) => {
   const year = String(2024 + index);
@@ -88,7 +36,7 @@ const dayOptions = Array.from({ length: 31 }).map((_, index) => {
   return { label: `${Number(day)}일`, value: day };
 });
 
-const employmentOptions: SegmentedToggleOption[] = [
+const employmentOptions: SegmentedToggleOption<EmploymentType>[] = [
   { label: "상용직 근로자", value: "regular" },
   { label: "일용직 근로자", value: "daily" },
 ];
@@ -195,14 +143,51 @@ export default function CompanyAttendancePage({ params }: Props) {
 
   const navItems = useMemo(() => buildCompanyNavItems(params.siteId), [params.siteId]);
 
-  const [employmentType, setEmploymentType] = useState("regular");
+  const [employmentType, setEmploymentType] = useState<EmploymentType>("regular");
   const [selectedDate, setSelectedDate] = useState<InlineDateValue>({
     year: "2025",
     month: "09",
     day: "10",
   });
 
-  const records = employmentType === "regular" ? regularAttendanceRecords : dailyAttendanceRecords;
+  const selectedDateKey = useMemo(
+    () => `${selectedDate.year}-${selectedDate.month}-${selectedDate.day}`,
+    [selectedDate],
+  );
+
+  const attendanceQuery = useAttendanceRecords({
+    siteId: params.siteId,
+    employmentType,
+    date: selectedDateKey,
+  });
+
+  const attendanceData = attendanceQuery.data;
+  const attendanceRecords = attendanceData?.records ?? [];
+  const totalWorkers = attendanceData?.totalWorkers ?? attendanceRecords.length;
+  const presentWorkers =
+    attendanceData?.checkedInWorkers ??
+    attendanceRecords.filter((record) => record.status !== "absent").length;
+
+  const summaryCounts = useMemo<Record<AttendanceStatus, number>>(() => {
+    const base: Record<AttendanceStatus, number> = {
+      normal: 0,
+      late: 0,
+      earlyLeave: 0,
+      absent: 0,
+    };
+
+    if (attendanceData?.summary) {
+      return { ...base, ...attendanceData.summary };
+    }
+
+    return attendanceRecords.reduce((acc, record) => {
+      acc[record.status] += 1;
+      return acc;
+    }, base);
+  }, [attendanceData?.summary, attendanceRecords]);
+
+  const attendanceError =
+    attendanceQuery.error instanceof Error ? attendanceQuery.error.message : null;
 
   return (
     <div className="min-h-full bg-bg-page px-4 py-6 dark:bg-dark-bg-page sm:px-6 lg:px-10 lg:py-8">
@@ -238,38 +223,54 @@ export default function CompanyAttendancePage({ params }: Props) {
             </div>
 
             <div className="flex items-center gap-3">
-              <p className="!mb-0 text-sm text-text-subtle dark:text-dark-text-base">4명 / 20명</p>
+              <p className="!mb-0 text-sm text-text-subtle dark:text-dark-text-base">
+                {`${presentWorkers}명 / ${totalWorkers}명`}
+              </p>
               <button
                 type="button"
                 className="flex h-10 w-10 items-center justify-center rounded-xl border border-border text-text-subtle hover:bg-bg-subtle dark:border-dark-border dark:text-dark-text-base dark:hover:bg-dark-bg-surface"
+                onClick={() => void attendanceQuery.refetch()}
+                disabled={attendanceQuery.isFetching || attendanceQuery.isLoading}
+                aria-label="근태 정보 새로고침"
               >
-                ↻
+                <span
+                  className={cn(
+                    "text-lg",
+                    attendanceQuery.isFetching || attendanceQuery.isLoading ? "animate-spin" : "",
+                  )}
+                >
+                  ↻
+                </span>
               </button>
             </div>
           </div>
 
+          {attendanceError ? (
+            <p className="mt-3 text-sm text-red-500">{attendanceError}</p>
+          ) : null}
+
           <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
             <AttendanceSummaryCard
               label="정상 출근"
-              value="15명"
+              value={`${summaryCounts.normal}명`}
               dotColor="bg-green-500"
               textColor="text-green-600"
             />
             <AttendanceSummaryCard
               label="지각"
-              value="2명"
+              value={`${summaryCounts.late}명`}
               dotColor="bg-yellow-400"
               textColor="text-yellow-600"
             />
             <AttendanceSummaryCard
               label="조퇴"
-              value="0명"
+              value={`${summaryCounts.earlyLeave}명`}
               dotColor="bg-orange-500"
               textColor="text-orange-600"
             />
             <AttendanceSummaryCard
               label="결근"
-              value="3명"
+              value={`${summaryCounts.absent}명`}
               dotColor="bg-red-500"
               textColor="text-red-600"
             />
@@ -279,8 +280,9 @@ export default function CompanyAttendancePage({ params }: Props) {
         <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
           <Table<AttendanceRecord>
             columns={attendanceColumns}
-            dataSource={records}
+            dataSource={attendanceRecords}
             rowKey="id"
+            loading={attendanceQuery.isLoading || attendanceQuery.isFetching}
             pagination={{
               pageSize: 10,
               position: ["bottomRight"],

--- a/src/hooks/use-attendance-records.ts
+++ b/src/hooks/use-attendance-records.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getAttendanceRecords,
+  type AttendanceRequestParams,
+} from "@/lib/api/get-attendance";
+
+type UseAttendanceRecordsOptions = AttendanceRequestParams & {
+  enabled?: boolean;
+};
+
+export function useAttendanceRecords({
+  enabled = true,
+  ...params
+}: UseAttendanceRecordsOptions) {
+  return useQuery({
+    queryKey: ["attendance-records", params.siteId, params.employmentType, params.date],
+    queryFn: () => getAttendanceRecords(params),
+    enabled,
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 10,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+  });
+}

--- a/src/lib/api/get-attendance.ts
+++ b/src/lib/api/get-attendance.ts
@@ -1,0 +1,98 @@
+"use client";
+
+export type AttendanceStatus = "normal" | "late" | "earlyLeave" | "absent";
+
+export type EmploymentType = "regular" | "daily";
+
+export type AttendanceRecord = {
+  id: string;
+  name: string;
+  ssnMasked: string;
+  status: AttendanceStatus;
+  clockIn?: string;
+  clockOut?: string;
+  totalHours?: string;
+  overtimeSummary?: string;
+};
+
+export type AttendanceSummary = Record<AttendanceStatus, number>;
+
+export type AttendanceRequestParams = {
+  siteId: string;
+  employmentType: EmploymentType;
+  date: string;
+};
+
+export type AttendanceResponse = {
+  records: AttendanceRecord[];
+  totalWorkers: number;
+  checkedInWorkers: number;
+  summary?: AttendanceSummary;
+};
+
+type AttendanceApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    records?: AttendanceRecord[];
+    totalWorkers?: number;
+    checkedInWorkers?: number;
+    summary?: AttendanceSummary;
+  };
+};
+
+const FALLBACK_ERROR =
+  "근태 정보를 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+
+export async function getAttendanceRecords({
+  siteId,
+  employmentType,
+  date,
+}: AttendanceRequestParams): Promise<AttendanceResponse> {
+  const searchParams = new URLSearchParams({
+    employmentType,
+    date,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(`/api/v1/sites/${siteId}/attendance?${searchParams.toString()}`, {
+      method: "GET",
+      credentials: "include",
+    });
+  } catch {
+    throw new Error(FALLBACK_ERROR);
+  }
+
+  let json: AttendanceApiResponse | null = null;
+  try {
+    json = (await response.json()) as AttendanceApiResponse;
+  } catch {
+    json = null;
+  }
+
+  if (!response.ok) {
+    throw new Error(json?.message || FALLBACK_ERROR);
+  }
+
+  if (!json?.success || !json.data) {
+    throw new Error(json?.message || FALLBACK_ERROR);
+  }
+
+  const records = json.data.records ?? [];
+
+  const checkedInWorkers =
+    typeof json.data.checkedInWorkers === "number"
+      ? json.data.checkedInWorkers
+      : records.filter((record) => record.status !== "absent").length;
+
+  const totalWorkers =
+    typeof json.data.totalWorkers === "number" ? json.data.totalWorkers : records.length;
+
+  return {
+    records,
+    checkedInWorkers,
+    totalWorkers,
+    summary: json.data.summary,
+  };
+}


### PR DESCRIPTION
## 🎯 변경 사항

- 근태 정보 API 호출 로직을 TanStack Query 기반으로 변경하여 캐싱을 적용하고, 수동 새로고침 시에만 데이터를 다시 불러오도록 개선했습니다.
- 근태 정보 API 호출 함수 및 관련 타입 정의를 `src/lib/api/get-attendance.ts`에 추가했습니다.
- 근태 데이터를 관리하는 `useAttendanceRecords` 커스텀 훅을 `src/hooks/use-attendance-records.ts`에 구현했습니다.
- `attendance/page.tsx`에서 기존 목업 데이터를 제거하고, `useAttendanceRecords` 훅을 연동하여 실제 데이터를 표시하고 새로고침 기능을 추가했습니다.

## 📝 사용 방법

- `src/app/(company)/company/[siteId]/attendance` 페이지에 접속합니다.
- 페이지 진입 시 캐시된 데이터가 표시되며, 새로고침 버튼을 클릭해야만 최신 데이터를 불러옵니다.
- 날짜 및 고용 형태 변경 시에도 캐시된 데이터가 사용되며, 각 조합별로 데이터가 캐싱됩니다.
- 새로고침 버튼 클릭 시 로딩 스피너가 표시되고, 테이블에도 로딩 상태가 반영됩니다.

## ✅ 테스트

- [x] `attendance/page.tsx` 페이지 진입 시 데이터가 정상적으로 로드되는지 확인
- [x] 새로고침 버튼 클릭 시 데이터가 다시 로드되고 UI가 업데이트되는지 확인
- [x] 날짜 및 고용 형태 변경 시 해당 조건에 맞는 데이터가 로드되는지 확인
- [x] 네트워크 요청 탭에서 페이지 진입 시 최초 1회만 API가 호출되고, 새로고침 버튼 클릭 시에만 추가 호출되는지 확인
- [x] API 호출 실패 시 에러 메시지가 표시되는지 확인

## 🔗 관련 이슈

- Jira: resolves
- resolves

---
<a href="https://cursor.com/background-agent?bcId=bc-da0a04d7-d057-4012-88c1-37501e79eac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da0a04d7-d057-4012-88c1-37501e79eac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

