### PR TITLE
[BU-192, #61] feat: 기업 근태관리 대시보드 구현

### DIFF
--- a/src/app/(company)/company/[siteId]/attendance/page.tsx
+++ b/src/app/(company)/company/[siteId]/attendance/page.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ColumnsType } from "antd/es/table";
+
+import { CompanyTopNav } from "@/components/features/company/company-top-nav";
+import {
+  InlineDateFilters,
+  type InlineDateValue,
+} from "@/components/common/filters/inline-date-filters";
+import {
+  SegmentedToggle,
+  type SegmentedToggleOption,
+} from "@/components/common/toggles/segmented-toggle";
+import { Table } from "@/components/ui/Table/table";
+import { cn } from "@/utils/cn";
+import { buildCompanyNavItems } from "@/constants/company-nav";
+import { useCompanySites } from "@/hooks/use-company-sites";
+
+type AttendanceStatus = "normal" | "late" | "earlyLeave" | "absent";
+
+type AttendanceRecord = {
+  id: string;
+  name: string;
+  ssnMasked: string;
+  status: AttendanceStatus;
+  clockIn?: string;
+  clockOut?: string;
+  totalHours?: string;
+  overtimeSummary?: string;
+};
+
+const regularAttendanceRecords: AttendanceRecord[] = [
+  {
+    id: "r1",
+    name: "김철수",
+    ssnMasked: "850101-1******",
+    status: "normal",
+    clockIn: "08:00",
+    clockOut: "18:00",
+    totalHours: "8시간",
+    overtimeSummary: "2시간 / - / -",
+  },
+  {
+    id: "r2",
+    name: "박영희",
+    ssnMasked: "920315-2******",
+    status: "late",
+    clockIn: "08:30",
+    clockOut: "18:00",
+    totalHours: "7.5시간",
+    overtimeSummary: "1.5시간 / 1시간 / -",
+  },
+  {
+    id: "r3",
+    name: "이민수",
+    ssnMasked: "880722-1******",
+    status: "normal",
+    clockIn: "07:55",
+    clockOut: "18:30",
+    totalHours: "8.5시간",
+    overtimeSummary: "2.5시간 / - / -",
+  },
+  {
+    id: "r4",
+    name: "최정훈",
+    ssnMasked: "750908-1******",
+    status: "absent",
+    clockIn: "-",
+    clockOut: "-",
+    totalHours: "-",
+    overtimeSummary: "-",
+  },
+];
+
+const dailyAttendanceRecords: AttendanceRecord[] = regularAttendanceRecords;
+
+const yearOptions = Array.from({ length: 3 }).map((_, index) => {
+  const year = String(2024 + index);
+  return { label: `${year}년`, value: year };
+});
+const monthOptions = Array.from({ length: 12 }).map((_, index) => {
+  const month = String(index + 1).padStart(2, "0");
+  return { label: `${Number(month)}월`, value: month };
+});
+const dayOptions = Array.from({ length: 31 }).map((_, index) => {
+  const day = String(index + 1).padStart(2, "0");
+  return { label: `${Number(day)}일`, value: day };
+});
+
+const employmentOptions: SegmentedToggleOption[] = [
+  { label: "상용직 근로자", value: "regular" },
+  { label: "일용직 근로자", value: "daily" },
+];
+
+const renderStatusPill = (status: AttendanceStatus) => {
+  switch (status) {
+    case "normal":
+      return (
+        <span className="inline-flex items-center rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700">
+          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-green-500" />
+          정상
+        </span>
+      );
+    case "late":
+      return (
+        <span className="inline-flex items-center rounded-full bg-yellow-50 px-3 py-1 text-xs font-medium text-yellow-800">
+          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-yellow-400" />
+          지각
+        </span>
+      );
+    case "earlyLeave":
+      return (
+        <span className="inline-flex items-center rounded-full bg-orange-50 px-3 py-1 text-xs font-medium text-orange-800">
+          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-orange-500" />
+          조퇴
+        </span>
+      );
+    case "absent":
+      return (
+        <span className="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-xs font-medium text-red-800">
+          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-red-500" />
+          결근
+        </span>
+      );
+    default:
+      return null;
+  }
+};
+
+const attendanceColumns: ColumnsType<AttendanceRecord> = [
+  {
+    title: "근로자명",
+    dataIndex: "name",
+    key: "name",
+    align: "center",
+  },
+  {
+    title: "주민등록번호",
+    dataIndex: "ssnMasked",
+    key: "ssnMasked",
+    align: "center",
+  },
+  {
+    title: "근태 상태",
+    dataIndex: "status",
+    key: "status",
+    align: "center",
+    render: (_value, record) => renderStatusPill(record.status),
+  },
+  {
+    title: "출근시간",
+    dataIndex: "clockIn",
+    key: "clockIn",
+    align: "center",
+    render: (value: AttendanceRecord["clockIn"]) => value ?? "-",
+  },
+  {
+    title: "퇴근시간",
+    dataIndex: "clockOut",
+    key: "clockOut",
+    align: "center",
+    render: (value: AttendanceRecord["clockOut"]) => value ?? "-",
+  },
+  {
+    title: "총 근로시간",
+    dataIndex: "totalHours",
+    key: "totalHours",
+    align: "center",
+    render: (value: AttendanceRecord["totalHours"]) => value ?? "-",
+  },
+  {
+    title: "야간/연장/휴일",
+    dataIndex: "overtimeSummary",
+    key: "overtimeSummary",
+    align: "center",
+    render: (value: AttendanceRecord["overtimeSummary"]) => value ?? "-",
+  },
+  // ...
+];
+
+type Props = {
+  params: {
+    siteId: string;
+  };
+};
+
+export default function CompanyAttendancePage({ params }: Props) {
+  const { data } = useCompanySites();
+  const sites = useMemo(() => data?.sites ?? [], [data]);
+  const currentSite = useMemo(
+    () => sites.find((site) => String(site.siteId) === params.siteId),
+    [sites, params.siteId],
+  );
+
+  const navItems = useMemo(() => buildCompanyNavItems(params.siteId), [params.siteId]);
+
+  const [employmentType, setEmploymentType] = useState("regular");
+  const [selectedDate, setSelectedDate] = useState<InlineDateValue>({
+    year: "2025",
+    month: "09",
+    day: "10",
+  });
+
+  const records = employmentType === "regular" ? regularAttendanceRecords : dailyAttendanceRecords;
+
+  return (
+    <div className="min-h-full bg-bg-page px-4 py-6 dark:bg-dark-bg-page sm:px-6 lg:px-10 lg:py-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <div className="flex flex-col gap-4">
+          <CompanyTopNav items={navItems} defaultActiveId="attendance" />
+          <header className="space-y-1">
+            <h1 className="mb-0! text-3xl font-bold! text-text-strong dark:text-dark-text-strong">
+              {currentSite?.siteName ?? "현장 이름을 불러오는 중..."}
+            </h1>
+            <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
+              오늘 현장의 근태 현황을 한눈에 확인하세요
+            </p>
+          </header>
+        </div>
+
+        <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap gap-3">
+              <InlineDateFilters
+                value={selectedDate}
+                yearOptions={yearOptions}
+                monthOptions={monthOptions}
+                dayOptions={dayOptions}
+                onChange={setSelectedDate}
+              />
+
+              <SegmentedToggle
+                value={employmentType}
+                onChange={setEmploymentType}
+                options={employmentOptions}
+              />
+            </div>
+
+            <div className="flex items-center gap-3">
+              <p className="!mb-0 text-sm text-text-subtle dark:text-dark-text-base">4명 / 20명</p>
+              <button
+                type="button"
+                className="flex h-10 w-10 items-center justify-center rounded-xl border border-border text-text-subtle hover:bg-bg-subtle dark:border-dark-border dark:text-dark-text-base dark:hover:bg-dark-bg-surface"
+              >
+                ↻
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <AttendanceSummaryCard
+              label="정상 출근"
+              value="15명"
+              dotColor="bg-green-500"
+              textColor="text-green-600"
+            />
+            <AttendanceSummaryCard
+              label="지각"
+              value="2명"
+              dotColor="bg-yellow-400"
+              textColor="text-yellow-600"
+            />
+            <AttendanceSummaryCard
+              label="조퇴"
+              value="0명"
+              dotColor="bg-orange-500"
+              textColor="text-orange-600"
+            />
+            <AttendanceSummaryCard
+              label="결근"
+              value="3명"
+              dotColor="bg-red-500"
+              textColor="text-red-600"
+            />
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
+          <Table<AttendanceRecord>
+            columns={attendanceColumns}
+            dataSource={records}
+            rowKey="id"
+            pagination={{
+              pageSize: 10,
+              position: ["bottomRight"],
+              showSizeChanger: false,
+            }}
+            showHeaderBar={false}
+            borderedContainer={false}
+            className="rounded-2xl border border-border dark:border-dark-border"
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+type AttendanceSummaryCardProps = {
+  label: string;
+  value: string;
+  dotColor: string;
+  textColor: string;
+};
+
+function AttendanceSummaryCard({ label, value, dotColor, textColor }: AttendanceSummaryCardProps) {
+  return (
+    <div className="rounded-2xl border border-border bg-white px-5 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+      <div className="flex items-center gap-2 text-sm">
+        <span className={cn("h-2 w-2 rounded-full", dotColor)} />
+        <span className="text-text-subtle dark:text-dark-text-base">{label}</span>
+      </div>
+      <p className={cn("mt-1 text-2xl font-semibold", textColor)}>{value}</p>
+    </div>
+  );
+}

--- a/src/app/(company)/company/[siteId]/attendance/page.tsx
+++ b/src/app/(company)/company/[siteId]/attendance/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import type { ColumnsType } from "antd/es/table";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { notification } from "antd";
 
 import { CompanyTopNav } from "@/components/features/company/company-top-nav";
 import {
@@ -12,171 +12,15 @@ import {
   SegmentedToggle,
   type SegmentedToggleOption,
 } from "@/components/common/toggles/segmented-toggle";
-import { Table } from "@/components/ui/Table/table";
-import { cn } from "@/utils/cn";
+import { AttendanceSummarySection } from "@/components/features/company/attendance/attendance-summary-section";
+import { AttendanceTable } from "@/components/features/company/attendance/attendance-table";
 import { buildCompanyNavItems } from "@/constants/company-nav";
 import { useCompanySites } from "@/hooks/use-company-sites";
-
-type AttendanceStatus = "normal" | "late" | "earlyLeave" | "absent";
-
-type AttendanceRecord = {
-  id: string;
-  name: string;
-  ssnMasked: string;
-  status: AttendanceStatus;
-  clockIn?: string;
-  clockOut?: string;
-  totalHours?: string;
-  overtimeSummary?: string;
-};
-
-const regularAttendanceRecords: AttendanceRecord[] = [
-  {
-    id: "r1",
-    name: "김철수",
-    ssnMasked: "850101-1******",
-    status: "normal",
-    clockIn: "08:00",
-    clockOut: "18:00",
-    totalHours: "8시간",
-    overtimeSummary: "2시간 / - / -",
-  },
-  {
-    id: "r2",
-    name: "박영희",
-    ssnMasked: "920315-2******",
-    status: "late",
-    clockIn: "08:30",
-    clockOut: "18:00",
-    totalHours: "7.5시간",
-    overtimeSummary: "1.5시간 / 1시간 / -",
-  },
-  {
-    id: "r3",
-    name: "이민수",
-    ssnMasked: "880722-1******",
-    status: "normal",
-    clockIn: "07:55",
-    clockOut: "18:30",
-    totalHours: "8.5시간",
-    overtimeSummary: "2.5시간 / - / -",
-  },
-  {
-    id: "r4",
-    name: "최정훈",
-    ssnMasked: "750908-1******",
-    status: "absent",
-    clockIn: "-",
-    clockOut: "-",
-    totalHours: "-",
-    overtimeSummary: "-",
-  },
-];
-
-const dailyAttendanceRecords: AttendanceRecord[] = regularAttendanceRecords;
-
-const yearOptions = Array.from({ length: 3 }).map((_, index) => {
-  const year = String(2024 + index);
-  return { label: `${year}년`, value: year };
-});
-const monthOptions = Array.from({ length: 12 }).map((_, index) => {
-  const month = String(index + 1).padStart(2, "0");
-  return { label: `${Number(month)}월`, value: month };
-});
-const dayOptions = Array.from({ length: 31 }).map((_, index) => {
-  const day = String(index + 1).padStart(2, "0");
-  return { label: `${Number(day)}일`, value: day };
-});
+import { useAttendanceRecords } from "@/hooks/use-attendance-records";
 
 const employmentOptions: SegmentedToggleOption[] = [
-  { label: "상용직 근로자", value: "regular" },
-  { label: "일용직 근로자", value: "daily" },
-];
-
-const renderStatusPill = (status: AttendanceStatus) => {
-  switch (status) {
-    case "normal":
-      return (
-        <span className="inline-flex items-center rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700">
-          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-green-500" />
-          정상
-        </span>
-      );
-    case "late":
-      return (
-        <span className="inline-flex items-center rounded-full bg-yellow-50 px-3 py-1 text-xs font-medium text-yellow-800">
-          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-yellow-400" />
-          지각
-        </span>
-      );
-    case "earlyLeave":
-      return (
-        <span className="inline-flex items-center rounded-full bg-orange-50 px-3 py-1 text-xs font-medium text-orange-800">
-          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-orange-500" />
-          조퇴
-        </span>
-      );
-    case "absent":
-      return (
-        <span className="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-xs font-medium text-red-800">
-          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-red-500" />
-          결근
-        </span>
-      );
-    default:
-      return null;
-  }
-};
-
-const attendanceColumns: ColumnsType<AttendanceRecord> = [
-  {
-    title: "근로자명",
-    dataIndex: "name",
-    key: "name",
-    align: "center",
-  },
-  {
-    title: "주민등록번호",
-    dataIndex: "ssnMasked",
-    key: "ssnMasked",
-    align: "center",
-  },
-  {
-    title: "근태 상태",
-    dataIndex: "status",
-    key: "status",
-    align: "center",
-    render: (_value, record) => renderStatusPill(record.status),
-  },
-  {
-    title: "출근시간",
-    dataIndex: "clockIn",
-    key: "clockIn",
-    align: "center",
-    render: (value: AttendanceRecord["clockIn"]) => value ?? "-",
-  },
-  {
-    title: "퇴근시간",
-    dataIndex: "clockOut",
-    key: "clockOut",
-    align: "center",
-    render: (value: AttendanceRecord["clockOut"]) => value ?? "-",
-  },
-  {
-    title: "총 근로시간",
-    dataIndex: "totalHours",
-    key: "totalHours",
-    align: "center",
-    render: (value: AttendanceRecord["totalHours"]) => value ?? "-",
-  },
-  {
-    title: "야간/연장/휴일",
-    dataIndex: "overtimeSummary",
-    key: "overtimeSummary",
-    align: "center",
-    render: (value: AttendanceRecord["overtimeSummary"]) => value ?? "-",
-  },
-  // ...
+  { label: "상용직 근로자", value: "REGULAR" },
+  { label: "일용직 근로자", value: "DAILY" },
 ];
 
 type Props = {
@@ -186,8 +30,8 @@ type Props = {
 };
 
 export default function CompanyAttendancePage({ params }: Props) {
-  const { data } = useCompanySites();
-  const sites = useMemo(() => data?.sites ?? [], [data]);
+  const { data: sitesData } = useCompanySites();
+  const sites = useMemo(() => sitesData?.sites ?? [], [sitesData]);
   const currentSite = useMemo(
     () => sites.find((site) => String(site.siteId) === params.siteId),
     [sites, params.siteId],
@@ -195,14 +39,79 @@ export default function CompanyAttendancePage({ params }: Props) {
 
   const navItems = useMemo(() => buildCompanyNavItems(params.siteId), [params.siteId]);
 
-  const [employmentType, setEmploymentType] = useState("regular");
+  const [employmentType, setEmploymentType] = useState<"REGULAR" | "DAILY">("REGULAR");
+  const today = useMemo(() => new Date(), []);
   const [selectedDate, setSelectedDate] = useState<InlineDateValue>({
-    year: "2025",
-    month: "09",
-    day: "10",
+    year: String(today.getFullYear()),
+    month: String(today.getMonth() + 1).padStart(2, "0"),
+    day: String(today.getDate()).padStart(2, "0"),
   });
 
-  const records = employmentType === "regular" ? regularAttendanceRecords : dailyAttendanceRecords;
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+
+  const {
+    data: attendanceData,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useAttendanceRecords({
+    siteId: Number(params.siteId),
+    year: selectedDate.year,
+    month: selectedDate.month,
+    day: selectedDate.day,
+    employmentType,
+    page,
+    size: pageSize,
+  });
+
+  const records = useMemo(() => attendanceData?.records ?? [], [attendanceData]);
+  const summary = attendanceData?.summary;
+  const pagination = attendanceData?.pagination;
+  const totalRecords = pagination?.totalRecords ?? 0;
+  const normalAttendanceCount = summary?.normalAttendance ?? 0;
+  const tableLoading = isLoading || isFetching;
+
+  const lastErrorMessageRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isError || !error) {
+      lastErrorMessageRef.current = null;
+      return;
+    }
+    const message =
+      error instanceof Error ? error.message : "근태 데이터를 불러오는 중 오류가 발생했습니다.";
+    if (lastErrorMessageRef.current === message) return;
+    lastErrorMessageRef.current = message;
+    notification.error({
+      message,
+      placement: "topRight",
+      duration: 3,
+    });
+  }, [isError, error]);
+
+  const yearOptions = useMemo(() => {
+    return Array.from({ length: 3 }).map((_, index) => {
+      const year = String(today.getFullYear() - 1 + index);
+      return { label: `${year}년`, value: year };
+    });
+  }, [today]);
+
+  const monthOptions = useMemo(() => {
+    return Array.from({ length: 12 }).map((_, index) => {
+      const month = String(index + 1).padStart(2, "0");
+      return { label: `${Number(month)}월`, value: month };
+    });
+  }, []);
+
+  const dayOptions = useMemo(() => {
+    return Array.from({ length: 31 }).map((_, index) => {
+      const day = String(index + 1).padStart(2, "0");
+      return { label: `${Number(day)}일`, value: day };
+    });
+  }, []);
 
   return (
     <div className="min-h-full bg-bg-page px-4 py-6 dark:bg-dark-bg-page sm:px-6 lg:px-10 lg:py-8">
@@ -227,20 +136,29 @@ export default function CompanyAttendancePage({ params }: Props) {
                 yearOptions={yearOptions}
                 monthOptions={monthOptions}
                 dayOptions={dayOptions}
-                onChange={setSelectedDate}
+                onChange={(newDate) => {
+                  setSelectedDate(newDate);
+                  setPage(1);
+                }}
               />
 
               <SegmentedToggle
                 value={employmentType}
-                onChange={setEmploymentType}
+                onChange={(val) => {
+                  setEmploymentType(val as "REGULAR" | "DAILY");
+                  setPage(1);
+                }}
                 options={employmentOptions}
               />
             </div>
 
             <div className="flex items-center gap-3">
-              <p className="!mb-0 text-sm text-text-subtle dark:text-dark-text-base">4명 / 20명</p>
+              <p className="mb-0! text-sm text-text-subtle dark:text-dark-text-base">
+                {tableLoading ? "로딩 중..." : `${normalAttendanceCount}명 / ${totalRecords}명`}
+              </p>
               <button
                 type="button"
+                onClick={() => refetch()}
                 className="flex h-10 w-10 items-center justify-center rounded-xl border border-border text-text-subtle hover:bg-bg-subtle dark:border-dark-border dark:text-dark-text-base dark:hover:bg-dark-bg-surface"
               >
                 ↻
@@ -248,69 +166,25 @@ export default function CompanyAttendancePage({ params }: Props) {
             </div>
           </div>
 
-          <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-            <AttendanceSummaryCard
-              label="정상 출근"
-              value="15명"
-              dotColor="bg-green-500"
-              textColor="text-green-600"
-            />
-            <AttendanceSummaryCard
-              label="지각"
-              value="2명"
-              dotColor="bg-yellow-400"
-              textColor="text-yellow-600"
-            />
-            <AttendanceSummaryCard
-              label="조퇴"
-              value="0명"
-              dotColor="bg-orange-500"
-              textColor="text-orange-600"
-            />
-            <AttendanceSummaryCard
-              label="결근"
-              value="3명"
-              dotColor="bg-red-500"
-              textColor="text-red-600"
-            />
-          </div>
+          <AttendanceSummarySection summary={summary} />
         </section>
 
         <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
-          <Table<AttendanceRecord>
-            columns={attendanceColumns}
-            dataSource={records}
-            rowKey="id"
-            pagination={{
-              pageSize: 10,
-              position: ["bottomRight"],
-              showSizeChanger: false,
+          <AttendanceTable
+            records={records}
+            isLoading={tableLoading}
+            currentPage={page}
+            pageSize={pageSize}
+            total={totalRecords}
+            locale={{
+              emptyText: isError
+                ? "근태 데이터를 불러오는 중 오류가 발생했습니다."
+                : "표시할 근태 데이터가 없습니다.",
             }}
-            showHeaderBar={false}
-            borderedContainer={false}
-            className="rounded-2xl border border-border dark:border-dark-border"
+            onPageChange={(newPage) => setPage(newPage)}
           />
         </section>
       </div>
-    </div>
-  );
-}
-
-type AttendanceSummaryCardProps = {
-  label: string;
-  value: string;
-  dotColor: string;
-  textColor: string;
-};
-
-function AttendanceSummaryCard({ label, value, dotColor, textColor }: AttendanceSummaryCardProps) {
-  return (
-    <div className="rounded-2xl border border-border bg-white px-5 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
-      <div className="flex items-center gap-2 text-sm">
-        <span className={cn("h-2 w-2 rounded-full", dotColor)} />
-        <span className="text-text-subtle dark:text-dark-text-base">{label}</span>
-      </div>
-      <p className={cn("mt-1 text-2xl font-semibold", textColor)}>{value}</p>
     </div>
   );
 }

--- a/src/components/common/filters/inline-date-filters.tsx
+++ b/src/components/common/filters/inline-date-filters.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { SelectProps } from "antd";
+import { Select } from "antd";
+
+import { cn } from "@/utils/cn";
+
+export type InlineDateValue = {
+  year: string;
+  month: string;
+  day: string;
+};
+
+export type InlineDateOption = {
+  label: string;
+  value: string;
+};
+
+type InlineDateFiltersProps = {
+  value: InlineDateValue;
+  yearOptions: InlineDateOption[];
+  monthOptions: InlineDateOption[];
+  dayOptions: InlineDateOption[];
+  onChange: (value: InlineDateValue) => void;
+  className?: string;
+  selectProps?: SelectProps;
+  popupClassName?: string;
+};
+
+export function InlineDateFilters({
+  value,
+  yearOptions,
+  monthOptions,
+  dayOptions,
+  onChange,
+  className,
+  selectProps,
+  popupClassName = "inline-date-filters-dropdown",
+}: InlineDateFiltersProps) {
+  const handleChange = (key: keyof InlineDateValue) => (selected: string) => {
+    onChange({ ...value, [key]: selected });
+  };
+
+  const sharedSelectProps = {
+    size: "large" as SelectProps["size"],
+    bordered: true,
+    ...selectProps,
+  };
+
+  return (
+    <div className={cn("flex flex-wrap gap-2", className)}>
+      <Select
+        {...sharedSelectProps}
+        className={cn("w-28 md:w-32", sharedSelectProps.className)}
+        options={yearOptions}
+        value={value.year}
+        onChange={handleChange("year")}
+        popupClassName={popupClassName}
+      />
+      <Select
+        {...sharedSelectProps}
+        className={cn("w-24 md:w-28", sharedSelectProps.className)}
+        options={monthOptions}
+        value={value.month}
+        onChange={handleChange("month")}
+        popupClassName={popupClassName}
+      />
+      <Select
+        {...sharedSelectProps}
+        className={cn("w-24 md:w-28", sharedSelectProps.className)}
+        options={dayOptions}
+        value={value.day}
+        onChange={handleChange("day")}
+        popupClassName={popupClassName}
+      />
+    </div>
+  );
+}

--- a/src/components/common/toggles/segmented-toggle.tsx
+++ b/src/components/common/toggles/segmented-toggle.tsx
@@ -2,31 +2,31 @@
 
 import { cn } from "@/utils/cn";
 
-export type EmploymentType = "regular" | "daily";
-
-type EmploymentToggleOption = {
+export type SegmentedToggleOption<TValue extends string = string> = {
   label: string;
-  value: EmploymentType;
+  value: TValue;
 };
 
-type EmploymentToggleProps = {
-  value: EmploymentType;
-  onChange: (value: EmploymentType) => void;
-  options?: EmploymentToggleOption[];
+type SegmentedToggleProps<TValue extends string = string> = {
+  value: TValue;
+  onChange: (value: TValue) => void;
+  options: SegmentedToggleOption<TValue>[];
+  className?: string;
 };
 
-const defaultOptions: EmploymentToggleOption[] = [
-  { label: "상용직 근로자", value: "regular" },
-  { label: "일용직 근로자", value: "daily" },
-];
-
-export function EmploymentToggle({
+export function SegmentedToggle<TValue extends string = string>({
   value,
   onChange,
-  options = defaultOptions,
-}: EmploymentToggleProps) {
+  options,
+  className,
+}: SegmentedToggleProps<TValue>) {
   return (
-    <div className="flex rounded-2xl bg-brand-primary-soft p-1 text-sm text-text-subtle shadow-sm dark:bg-dark-bg-surface dark:text-dark-text-base">
+    <div
+      className={cn(
+        "flex rounded-2xl bg-brand-primary-soft p-1 text-sm text-text-subtle shadow-sm dark:bg-dark-bg-surface dark:text-dark-text-base",
+        className,
+      )}
+    >
       {options.map((option) => {
         const isActive = option.value === value;
         return (

--- a/src/components/features/company/attendance/attendance-summary-card.tsx
+++ b/src/components/features/company/attendance/attendance-summary-card.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/utils/cn";
+
+type AttendanceSummaryCardProps = {
+  label: string;
+  value: string;
+  dotColor: string;
+  textColor: string;
+};
+
+export function AttendanceSummaryCard({
+  label,
+  value,
+  dotColor,
+  textColor,
+}: AttendanceSummaryCardProps) {
+  return (
+    <div className="rounded-2xl border border-border bg-white px-5 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+      <div className="flex items-center gap-2 text-sm">
+        <span className={cn("h-2 w-2 rounded-full", dotColor)} />
+        <span className="text-text-subtle dark:text-dark-text-base">{label}</span>
+      </div>
+      <p className={cn("mt-1 text-2xl font-semibold", textColor)}>{value}</p>
+    </div>
+  );
+}

--- a/src/components/features/company/attendance/attendance-summary-section.tsx
+++ b/src/components/features/company/attendance/attendance-summary-section.tsx
@@ -1,0 +1,38 @@
+import type { AttendanceSummary } from "@/lib/api/get-attendance-records";
+
+import { AttendanceSummaryCard } from "@/components/features/company/attendance/attendance-summary-card";
+
+type AttendanceSummarySectionProps = {
+  summary?: AttendanceSummary;
+};
+
+export function AttendanceSummarySection({ summary }: AttendanceSummarySectionProps) {
+  return (
+    <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <AttendanceSummaryCard
+        label="정상 출근"
+        value={`${summary?.normalAttendance ?? 0}명`}
+        dotColor="bg-green-500"
+        textColor="text-green-600"
+      />
+      <AttendanceSummaryCard
+        label="지각"
+        value={`${summary?.late ?? 0}명`}
+        dotColor="bg-yellow-400"
+        textColor="text-yellow-600"
+      />
+      <AttendanceSummaryCard
+        label="조퇴"
+        value={`${summary?.earlyLeave ?? 0}명`}
+        dotColor="bg-orange-500"
+        textColor="text-orange-600"
+      />
+      <AttendanceSummaryCard
+        label="결근"
+        value={`${summary?.absent ?? 0}명`}
+        dotColor="bg-red-500"
+        textColor="text-red-600"
+      />
+    </div>
+  );
+}

--- a/src/components/features/company/attendance/attendance-table.tsx
+++ b/src/components/features/company/attendance/attendance-table.tsx
@@ -1,0 +1,140 @@
+import type { ColumnsType } from "antd/es/table";
+
+import { Table, type TableProps as BaseTableProps } from "@/components/ui/Table/table";
+import type { AttendanceRecord } from "@/lib/api/get-attendance-records";
+
+type AttendanceTableProps = {
+  records: AttendanceRecord[];
+  isLoading: boolean;
+  currentPage: number;
+  pageSize: number;
+  total?: number;
+  onPageChange: (page: number) => void;
+  locale?: BaseTableProps<AttendanceRecord>["locale"];
+};
+
+const renderStatusPill = (status: string, isLate: boolean) => {
+  if (isLate) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-yellow-50 px-3 py-1 text-xs font-medium text-yellow-800">
+        <span className="mr-1 h-1.5 w-1.5 rounded-full bg-yellow-400" />
+        지각
+      </span>
+    );
+  }
+
+  switch (status) {
+    case "NORMAL":
+      return (
+        <span className="inline-flex items-center rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700">
+          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-green-500" />
+          정상
+        </span>
+      );
+    case "EARLY_LEAVE":
+      return (
+        <span className="inline-flex items-center rounded-full bg-orange-50 px-3 py-1 text-xs font-medium text-orange-800">
+          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-orange-500" />
+          조퇴
+        </span>
+      );
+    case "ABSENT":
+      return (
+        <span className="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-xs font-medium text-red-800">
+          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-red-500" />
+          결근
+        </span>
+      );
+    default:
+      return (
+        <span className="inline-flex items-center rounded-full bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700">
+          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-gray-400" />-
+        </span>
+      );
+  }
+};
+
+const attendanceColumns: ColumnsType<AttendanceRecord> = [
+  {
+    title: "근로자명",
+    dataIndex: "workerName",
+    key: "workerName",
+    align: "center",
+  },
+  {
+    title: "주민등록번호",
+    dataIndex: "residentNumber",
+    key: "residentNumber",
+    align: "center",
+  },
+  {
+    title: "근태 상태",
+    key: "status",
+    align: "center",
+    render: (_, record) => renderStatusPill(record.attendanceStatus, record.isLate),
+  },
+  {
+    title: "출근시간",
+    dataIndex: "checkInTime",
+    key: "checkInTime",
+    align: "center",
+    render: (value) => value ?? "-",
+  },
+  {
+    title: "퇴근시간",
+    dataIndex: "checkOutTime",
+    key: "checkOutTime",
+    align: "center",
+    render: (value) => value ?? "-",
+  },
+  {
+    title: "총 근로시간",
+    dataIndex: "totalWorkHours",
+    key: "totalWorkHours",
+    align: "center",
+    render: (value) => value ?? "-",
+  },
+  {
+    title: "야간/연장/휴일",
+    key: "overtimeSummary",
+    align: "center",
+    render: (_, record) => {
+      const night = record.nightWorkHours || "-";
+      const overtime = record.overtimeHours || "-";
+      const holiday = record.holidayWorkHours || "-";
+      if (night === "-" && overtime === "-" && holiday === "-") return "-";
+      return `${night} / ${overtime} / ${holiday}`;
+    },
+  },
+];
+
+export function AttendanceTable({
+  records,
+  isLoading,
+  currentPage,
+  pageSize,
+  total,
+  onPageChange,
+  locale,
+}: AttendanceTableProps) {
+  return (
+    <Table<AttendanceRecord>
+      columns={attendanceColumns}
+      dataSource={records}
+      rowKey="workerId"
+      loading={isLoading}
+      locale={locale}
+      pagination={{
+        current: currentPage,
+        pageSize,
+        total,
+        onChange: onPageChange,
+        position: ["bottomRight"],
+        showSizeChanger: false,
+      }}
+      showHeaderBar={false}
+      borderedContainer={false}
+      className="rounded-2xl border border-border dark:border-dark-border"
+    />
+  );
+}

--- a/src/components/features/company/attendance/employment-toggle.tsx
+++ b/src/components/features/company/attendance/employment-toggle.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { cn } from "@/utils/cn";
+
+export type EmploymentType = "regular" | "daily";
+
+type EmploymentToggleOption = {
+  label: string;
+  value: EmploymentType;
+};
+
+type EmploymentToggleProps = {
+  value: EmploymentType;
+  onChange: (value: EmploymentType) => void;
+  options?: EmploymentToggleOption[];
+};
+
+const defaultOptions: EmploymentToggleOption[] = [
+  { label: "상용직 근로자", value: "regular" },
+  { label: "일용직 근로자", value: "daily" },
+];
+
+export function EmploymentToggle({
+  value,
+  onChange,
+  options = defaultOptions,
+}: EmploymentToggleProps) {
+  return (
+    <div className="flex rounded-2xl bg-brand-primary-soft p-1 text-sm text-text-subtle shadow-sm dark:bg-dark-bg-surface dark:text-dark-text-base">
+      {options.map((option) => {
+        const isActive = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={cn(
+              "min-w-[132px] rounded-xl px-5 py-2 font-medium transition-colors",
+              isActive
+                ? "bg-brand-primary text-white shadow hover:bg-brand-primary/90"
+                : "text-text-subtle hover:text-text-strong dark:text-dark-text-base",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/Table/table.tsx
+++ b/src/components/ui/Table/table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Table as AntTable, type TableProps as AntTableProps } from "antd";
-import { ReactNode, type TdHTMLAttributes, type ThHTMLAttributes } from "react";
+import { type CSSProperties, ReactNode, type TdHTMLAttributes, type ThHTMLAttributes } from "react";
 
 import { cn } from "@/utils/cn";
 
@@ -13,6 +13,11 @@ export interface TableProps<RecordType extends Record<string, unknown>>
   density?: "comfortable" | "compact";
   headerExtra?: ReactNode;
   className?: string;
+  showHeaderBar?: boolean;
+  borderedContainer?: boolean;
+  headerCellClassName?: string;
+  headerCellStyle?: CSSProperties;
+  headerCellStyles?: CSSProperties[];
 }
 
 export function Table<RecordType extends Record<string, unknown> = Record<string, unknown>>({
@@ -21,19 +26,45 @@ export function Table<RecordType extends Record<string, unknown> = Record<string
   headerExtra,
   className,
   rowClassName,
+  showHeaderBar = true,
+  borderedContainer = true,
+  headerCellClassName,
+  headerCellStyle,
+  headerCellStyles,
   ...props
 }: TableProps<RecordType>) {
   const components: TableComponentProps<RecordType> = {
     header: {
-      cell: (cellProps: ThHTMLAttributes<HTMLTableCellElement>) => (
-        <th
-          {...cellProps}
-          className={cn(
-            cellProps.className,
-            "bg-bg-subtle text-left text-text-subtle text-xs font-semibold uppercase tracking-wide dark:bg-dark-bg-surface dark:text-dark-text-strong",
-          )}
-        />
-      ),
+      cell: (
+        cellProps: ThHTMLAttributes<HTMLTableCellElement> & {
+          column?: { key?: string };
+          columnIndex?: number;
+        },
+      ) => {
+        const columnIndex =
+          typeof cellProps.columnIndex === "number" ? cellProps.columnIndex : undefined;
+        const extraStyle =
+          typeof columnIndex === "number" && headerCellStyles?.[columnIndex]
+            ? headerCellStyles[columnIndex]
+            : undefined;
+
+        return (
+          <th
+            {...cellProps}
+            className={cn(
+              cellProps.className,
+              headerCellClassName ?? "!bg-state-info-weak",
+              "text-left !text-text-base text-xs font-semibold uppercase tracking-wide",
+              headerCellClassName ? undefined : "ant-table-cell",
+            )}
+            style={{
+              ...cellProps.style,
+              ...headerCellStyle,
+              ...extraStyle,
+            }}
+          />
+        );
+      },
     },
     body: {
       cell: (cellProps: TdHTMLAttributes<HTMLTableCellElement>) => (
@@ -41,11 +72,10 @@ export function Table<RecordType extends Record<string, unknown> = Record<string
           {...cellProps}
           className={cn(
             cellProps.className,
-            "text-left text-sm dark:text-[var(--color-dark-text-strong)]",
+            "text-left text-sm",
+            zebra ? "text-text-base dark:text-white" : "text-[#0b0f1a] dark:text-white",
           )}
-          style={{
-            color: zebra ? "var(--color-text-strong)" : "#0b0f1a",
-          }}
+          style={cellProps.style}
         />
       ),
     },
@@ -54,20 +84,25 @@ export function Table<RecordType extends Record<string, unknown> = Record<string
   return (
     <div
       className={cn(
-        "w-full overflow-hidden rounded-2xl border border-border dark:border-dark-border",
+        "w-full overflow-hidden [&_.ant-table-row:hover>td]:!bg-transparent [&_.ant-table-cell-row-hover]:!bg-transparent",
+        borderedContainer ? "rounded-2xl border border-border dark:border-dark-border" : "",
         className,
       )}
     >
-      <div className="flex items-center justify-between border-b border-border bg-bg-surface px-4 py-3 dark:border-dark-border dark:bg-dark-bg-surface">
-        {props.title ? (
-          <div className="text-base font-semibold text-text-strong dark:text-dark-text-strong">
-            {typeof props.title === "function" ? props.title(props.dataSource ?? []) : props.title}
-          </div>
-        ) : (
-          <span />
-        )}
-        {headerExtra}
-      </div>
+      {showHeaderBar && (
+        <div className="flex items-center justify-between border-b border-border bg-bg-surface px-4 py-3 dark:border-dark-border dark:bg-dark-bg-surface">
+          {props.title ? (
+            <div className="text-base font-semibold text-text-strong dark:text-dark-text-strong">
+              {typeof props.title === "function"
+                ? props.title(props.dataSource ?? [])
+                : props.title}
+            </div>
+          ) : (
+            <span />
+          )}
+          {headerExtra}
+        </div>
+      )}
       <AntTable<RecordType>
         pagination={props.pagination ?? false}
         components={components}

--- a/src/hooks/use-attendance-records.ts
+++ b/src/hooks/use-attendance-records.ts
@@ -1,0 +1,35 @@
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getAttendanceRecords,
+  type GetAttendanceRecordsParams,
+  type GetAttendanceRecordsResponse,
+} from "@/lib/api/get-attendance-records";
+
+export function useAttendanceRecords(params: GetAttendanceRecordsParams) {
+  const queryClient = useQueryClient();
+  const queryKey = [
+    "attendance",
+    "records",
+    params.siteId,
+    params.year,
+    params.month,
+    params.day,
+    params.employmentType,
+    params.page,
+    params.size,
+  ] as const;
+
+  const cachedData = queryClient.getQueryData<GetAttendanceRecordsResponse["data"]>(queryKey);
+
+  return useQuery<GetAttendanceRecordsResponse["data"]>({
+    queryKey,
+    queryFn: () => getAttendanceRecords(params),
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 30,
+    enabled: !cachedData,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/src/lib/api/get-attendance-records.ts
+++ b/src/lib/api/get-attendance-records.ts
@@ -1,0 +1,91 @@
+export type AttendanceStatus = "NORMAL" | "LATE" | "EARLY_LEAVE" | "ABSENT";
+
+export type AttendanceSummary = {
+  normalAttendance: number;
+  late: number;
+  earlyLeave: number;
+  absent: number;
+};
+
+export type AttendanceRecord = {
+  workerId: number;
+  workerName: string;
+  residentNumber: string;
+  attendanceStatus: string;
+  checkInTime: string;
+  checkOutTime: string;
+  totalWorkHours: string;
+  nightWorkHours: string;
+  overtimeHours: string;
+  holidayWorkHours: string;
+  isLate: boolean;
+};
+
+export type AttendancePagination = {
+  currentPage: number;
+  totalPages: number;
+  totalRecords: number;
+  pageSize: number;
+};
+
+export type GetAttendanceRecordsResponse = {
+  success: boolean;
+  message: string;
+  code: string;
+  data: {
+    summary: AttendanceSummary;
+    records: AttendanceRecord[];
+    pagination: AttendancePagination;
+  };
+};
+
+export type GetAttendanceRecordsParams = {
+  siteId: number;
+  year: string;
+  month: string;
+  day?: string;
+  employmentType: "REGULAR" | "DAILY";
+  page?: number;
+  size?: number;
+};
+
+export async function getAttendanceRecords({
+  siteId,
+  year,
+  month,
+  day,
+  employmentType,
+  page = 1,
+  size = 20,
+}: GetAttendanceRecordsParams): Promise<GetAttendanceRecordsResponse["data"]> {
+  const queryParams = new URLSearchParams({
+    year,
+    month,
+    employmentType,
+    page: page.toString(),
+    size: size.toString(),
+  });
+
+  if (day) {
+    queryParams.append("day", day);
+  }
+
+  const response = await fetch(`/api/v1/${siteId}/attendance/records?${queryParams.toString()}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("근태 현황을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetAttendanceRecordsResponse;
+
+  if (!json.success) {
+    throw new Error(json.message || "근태 현황을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  return json.data;
+}


### PR DESCRIPTION
## 🎯 변경 사항

근태관리 페이지가 TanStack Query 기반 데이터 캐싱을 사용하도록 구현해, 최초 조회 후에는 필터/페이지 이동 시 캐시된 데이터를 즉시 보여주고 새로고침 버튼을 눌렀을 때만 API를 다시 호출합니다.
근태 현황 요약 카드와 근태 테이블을 별도 컴포넌트로 분리해 페이지 레이아웃이 단순해지고 다른 화면에서도 동일 UI를 재활용할 수 있도록 구성했습니다.
근태 API 오류가 발생하면 상단에 토스트 알림을 띄우고, 테이블에는 오류 안내 문구를 노출해 사용자가 즉시 문제를 인지할 수 있게 했습니다.
상단 요약 카운터는 “정상 출근 인원 / 전체 인원” 포맷을 사용하도록 구현해 핵심 지표를 바로 확인할 수 있습니다.

## 📝 사용 방법

회사 > 특정 현장 > 근태관리 페이지로 이동합니다.
날짜 또는 고용형태 필터를 변경하거나 페이지네이션을 이동하면 캐시된 데이터가 즉시 반영됩니다.
데이터가 오래됐다면 상단 새로고침 버튼을 눌러 API를 수동으로 재호출해 최신 상태를 가져옵니다.
API 오류가 발생하면 화면 우측 상단에 에러 토스트가 노출되고 테이블에도 오류 메시지가 표시됩니다.

## ✅ 테스트

- [ ] 날짜/고용형태/페이지 변경 시 API 재호출 없이 캐시 데이터가 표시되는지 확인
- [ ] 새로고침 버튼 클릭 시에만 API가 호출되고 데이터가 최신으로 갱신되는지 확인
- [x] 서버 오류(500) 발생 시 토스트 알림과 테이블 내 오류 메시지가 정상 표시되는지 확인

## 🔗 관련 이슈

- Jira: resolves BU-192
- resolves #61 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회사 섹션에 직원 출근 기록 조회 페이지 추가
  * 연도, 월, 일별 인라인 날짜 필터링 기능 제공
  * 고용 유형(정규직/일용직) 토글 스위치로 데이터 필터링 가능
  * 출근 통계 요약 카드 및 페이지네이션 테이블 표시
  * 출근 상태(정상, 지각, 조퇴, 결근) 시각화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->