### PR TITLE
[BU-195, #67] feat: 기업 안전/작업 탭 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,31 @@ const nextConfig = {
       },
     ];
   },
+  webpack: (config, { isServer }) => {
+    // react-pdf와 pdfjs-dist를 클라이언트 사이드에서만 번들링
+    if (!isServer) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        canvas: false,
+      };
+
+      // react-pdf 관련 모듈을 externals로 처리하지 않도록 설정
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+        path: false,
+        crypto: false,
+      };
+    } else {
+      // 서버 사이드에서는 react-pdf를 externals로 처리
+      config.externals = config.externals || [];
+      config.externals.push({
+        "react-pdf": "commonjs react-pdf",
+        "pdfjs-dist": "commonjs pdfjs-dist",
+      });
+    }
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "antd": "^5.29.1",
     "clsx": "^2.1.1",
     "next": "14.2.10",
+    "pdfjs-dist": "^5.4.394",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-pdf": "^10.2.0",
     "tailwind-merge": "^2.5.2",
     "zustand": "^5.0.8"
   },
@@ -35,6 +37,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/react-pdf": "^7.0.0",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.10",

--- a/src/app/(company)/company/[siteId]/safety/page.tsx
+++ b/src/app/(company)/company/[siteId]/safety/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { notification } from "antd";
+import { useQuery } from "@tanstack/react-query";
 
 import {
   InlineDateFilters,
@@ -13,7 +14,11 @@ import { SafetyWorkTable } from "@/components/features/company/safety/safety-wor
 import { buildCompanyNavItems } from "@/constants/company-nav";
 import { useCompanySites } from "@/hooks/use-company-sites";
 import { useSafetyWorkRecords } from "@/hooks/use-safety-work-records";
-import type { SafetyWorkRecord } from "@/lib/api/get-safety-work-records";
+import {
+  getSafetyEducationLogPdfUrl,
+  getWorkReportPdfUrl,
+  type SafetyWorkRecord,
+} from "@/lib/api/get-safety-work-records";
 
 type Props = {
   params: {
@@ -107,6 +112,31 @@ export default function CompanySafetyPage({ params }: Props) {
   const [openDiaryRecord, setOpenDiaryRecord] = useState<SafetyWorkRecord | null>(null);
   const [openWorkReportRecord, setOpenWorkReportRecord] = useState<SafetyWorkRecord | null>(null);
 
+  // 안전교육일지 PDF URL 가져오기
+  const { data: safetyDiaryPdfUrl } = useQuery({
+    queryKey: [
+      "safety-education-log-pdf",
+      params.siteId,
+      openDiaryRecord?.safetyEducationLog?.logId,
+    ],
+    queryFn: () =>
+      getSafetyEducationLogPdfUrl(
+        Number(params.siteId),
+        openDiaryRecord!.safetyEducationLog!.logId,
+      ),
+    enabled: Boolean(openDiaryRecord?.safetyEducationLog?.logId),
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+
+  // 작업일보 PDF URL 가져오기
+  const { data: workReportPdfUrl } = useQuery({
+    queryKey: ["work-report-pdf", params.siteId, openWorkReportRecord?.workReport?.workReportId],
+    queryFn: () =>
+      getWorkReportPdfUrl(Number(params.siteId), openWorkReportRecord!.workReport!.workReportId),
+    enabled: Boolean(openWorkReportRecord?.workReport?.workReportId),
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+
   return (
     <div className="min-h-full bg-bg-page px-4 py-6 dark:bg-dark-bg-page sm:px-6 lg:px-10 lg:py-8">
       <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
@@ -178,10 +208,10 @@ export default function CompanySafetyPage({ params }: Props) {
         subtitle={
           openDiaryRecord ? `${currentSite?.siteName ?? ""} | ${openDiaryRecord.date}` : undefined
         }
-        pdfUrl={openDiaryRecord?.safetyDiaryUrl}
+        pdfUrl={safetyDiaryPdfUrl}
         onDownload={() => {
-          if (openDiaryRecord?.safetyDiaryUrl) {
-            window.open(openDiaryRecord.safetyDiaryUrl, "_blank");
+          if (safetyDiaryPdfUrl) {
+            window.open(safetyDiaryPdfUrl, "_blank");
           }
         }}
       />
@@ -195,10 +225,10 @@ export default function CompanySafetyPage({ params }: Props) {
             ? `${currentSite?.siteName ?? ""} | ${openWorkReportRecord.date}`
             : undefined
         }
-        pdfUrl={openWorkReportRecord?.workReportUrl}
+        pdfUrl={workReportPdfUrl}
         onDownload={() => {
-          if (openWorkReportRecord?.workReportUrl) {
-            window.open(openWorkReportRecord.workReportUrl, "_blank");
+          if (workReportPdfUrl) {
+            window.open(workReportPdfUrl, "_blank");
           }
         }}
       />

--- a/src/app/(company)/company/[siteId]/safety/page.tsx
+++ b/src/app/(company)/company/[siteId]/safety/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { notification } from "antd";
+
+import {
+  InlineDateFilters,
+  type InlineDateValue,
+} from "@/components/common/filters/inline-date-filters";
+import { CompanyTopNav } from "@/components/features/company/company-top-nav";
+import { SafetyDocumentModal } from "@/components/features/company/safety/safety-document-modal";
+import { SafetyWorkTable } from "@/components/features/company/safety/safety-work-table";
+import { buildCompanyNavItems } from "@/constants/company-nav";
+import { useCompanySites } from "@/hooks/use-company-sites";
+import { useSafetyWorkRecords } from "@/hooks/use-safety-work-records";
+import type { SafetyWorkRecord } from "@/lib/api/get-safety-work-records";
+
+type Props = {
+  params: {
+    siteId: string;
+  };
+};
+
+export default function CompanySafetyPage({ params }: Props) {
+  const { data: sitesData } = useCompanySites();
+  const sites = useMemo(() => sitesData?.sites ?? [], [sitesData]);
+  const currentSite = useMemo(
+    () => sites.find((site) => String(site.siteId) === params.siteId),
+    [sites, params.siteId],
+  );
+
+  const navItems = useMemo(() => buildCompanyNavItems(params.siteId), [params.siteId]);
+
+  const today = useMemo(() => new Date(), []);
+  const [selectedDate, setSelectedDate] = useState<InlineDateValue>({
+    year: String(today.getFullYear()),
+    month: String(today.getMonth() + 1).padStart(2, "0"),
+    day: String(today.getDate()).padStart(2, "0"),
+  });
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+
+  const {
+    data: safetyData,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useSafetyWorkRecords({
+    siteId: Number(params.siteId),
+    year: selectedDate.year,
+    month: selectedDate.month,
+    page,
+    size: pageSize,
+  });
+
+  const records = safetyData?.records ?? [];
+  const totalRecords = safetyData?.pagination.totalRecords ?? 0;
+  const totalCount = safetyData?.summary.totalCount ?? 0;
+  const tableLoading = isLoading || isFetching;
+
+  const lastErrorMessageRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isError && !error) {
+      lastErrorMessageRef.current = null;
+      return;
+    }
+    if (!isError || !error) {
+      return;
+    }
+    const message =
+      error instanceof Error
+        ? error.message
+        : "안전/작업 데이터를 불러오는 중 오류가 발생했습니다.";
+    if (lastErrorMessageRef.current === message) return;
+    lastErrorMessageRef.current = message;
+    notification.error({
+      message,
+      placement: "topRight",
+      duration: 3,
+    });
+  }, [isError, error]);
+
+  const yearOptions = useMemo(() => {
+    return Array.from({ length: 3 }).map((_, index) => {
+      const year = String(today.getFullYear() - 1 + index);
+      return { label: `${year}년`, value: year };
+    });
+  }, [today]);
+
+  const monthOptions = useMemo(() => {
+    return Array.from({ length: 12 }).map((_, index) => {
+      const month = String(index + 1).padStart(2, "0");
+      return { label: `${Number(month)}월`, value: month };
+    });
+  }, []);
+
+  const dayOptions = useMemo(() => {
+    return Array.from({ length: 31 }).map((_, index) => {
+      const day = String(index + 1).padStart(2, "0");
+      return { label: `${Number(day)}일`, value: day };
+    });
+  }, []);
+
+  const [openDiaryRecord, setOpenDiaryRecord] = useState<SafetyWorkRecord | null>(null);
+  const [openWorkReportRecord, setOpenWorkReportRecord] = useState<SafetyWorkRecord | null>(null);
+
+  return (
+    <div className="min-h-full bg-bg-page px-4 py-6 dark:bg-dark-bg-page sm:px-6 lg:px-10 lg:py-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <div className="flex flex-col gap-4">
+          <CompanyTopNav items={navItems} defaultActiveId="safety" />
+          <header className="space-y-1">
+            <h1 className="mb-0! text-3xl font-bold! text-text-strong dark:text-dark-text-strong">
+              {currentSite?.siteName ?? "현장 이름을 불러오는 중..."}
+            </h1>
+            <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
+              안전교육과 작업일보를 투명하게 관리하세요
+            </p>
+          </header>
+        </div>
+
+        <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <InlineDateFilters
+              value={selectedDate}
+              yearOptions={yearOptions}
+              monthOptions={monthOptions}
+              dayOptions={dayOptions}
+              hideDay
+              onChange={(newDate) => {
+                setSelectedDate(newDate);
+                setPage(1);
+              }}
+            />
+
+            <div className="flex items-center gap-3 text-sm text-text-subtle">
+              {tableLoading ? "로딩 중..." : `총 ${totalCount}건`}
+              <button
+                type="button"
+                onClick={() => refetch()}
+                className="flex h-10 w-10 items-center justify-center rounded-xl border border-border text-text-subtle hover:bg-bg-subtle dark:border-dark-border dark:text-dark-text-base dark:hover:bg-dark-bg-surface"
+              >
+                ↻
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-6 rounded-3xl border border-border bg-white p-6 shadow-sm dark:border-dark-border dark:bg-dark-bg-surface">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xl font-semibold text-text-strong">안전교육 및 작업일보</p>
+              </div>
+            </div>
+
+            <div className="mt-4">
+              <SafetyWorkTable
+                records={records}
+                isLoading={tableLoading}
+                currentPage={page}
+                pageSize={pageSize}
+                total={totalRecords}
+                onPageChange={(newPage) => setPage(newPage)}
+                onOpenSafetyDiary={(record) => setOpenDiaryRecord(record)}
+                onOpenWorkReport={(record) => setOpenWorkReportRecord(record)}
+              />
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <SafetyDocumentModal
+        open={Boolean(openDiaryRecord)}
+        onClose={() => setOpenDiaryRecord(null)}
+        title="안전교육일지"
+        subtitle={
+          openDiaryRecord ? `${currentSite?.siteName ?? ""} | ${openDiaryRecord.date}` : undefined
+        }
+        pdfUrl={openDiaryRecord?.safetyDiaryUrl}
+        onDownload={() => {
+          if (openDiaryRecord?.safetyDiaryUrl) {
+            window.open(openDiaryRecord.safetyDiaryUrl, "_blank");
+          }
+        }}
+      />
+
+      <SafetyDocumentModal
+        open={Boolean(openWorkReportRecord)}
+        onClose={() => setOpenWorkReportRecord(null)}
+        title="작업일보"
+        subtitle={
+          openWorkReportRecord
+            ? `${currentSite?.siteName ?? ""} | ${openWorkReportRecord.date}`
+            : undefined
+        }
+        pdfUrl={openWorkReportRecord?.workReportUrl}
+        onDownload={() => {
+          if (openWorkReportRecord?.workReportUrl) {
+            window.open(openWorkReportRecord.workReportUrl, "_blank");
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/common/pdf-viewer.tsx
+++ b/src/components/common/pdf-viewer.tsx
@@ -61,23 +61,6 @@ export function PDFViewer({ pdfUrl }: PDFViewerProps) {
           />
         )}
       </div>
-      <div className="flex items-center justify-center gap-2 text-sm text-text-subtle">
-        <Button variant="ghost" size="sm" onClick={() => window.open(pdfUrl, "_blank")}>
-          새 창에서 열기
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            const link = document.createElement("a");
-            link.href = pdfUrl;
-            link.download = "document.pdf";
-            link.click();
-          }}
-        >
-          다운로드
-        </Button>
-      </div>
     </div>
   );
 }

--- a/src/components/common/pdf-viewer.tsx
+++ b/src/components/common/pdf-viewer.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/Button/button";
+
+type PDFViewerProps = {
+  pdfUrl: string;
+};
+
+export function PDFViewer({ pdfUrl }: PDFViewerProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  const handleIframeLoad = () => {
+    setIsLoading(false);
+  };
+
+  const handleIframeError = () => {
+    setIsLoading(false);
+    setHasError(true);
+  };
+
+  return (
+    <div className="flex h-[600px] flex-col gap-4">
+      <div className="relative rounded-xl border border-border bg-white shadow-sm overflow-hidden">
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-bg-subtle z-10">
+            <p className="text-text-subtle">PDF를 불러오는 중입니다...</p>
+          </div>
+        )}
+        {hasError ? (
+          <div className="flex h-[600px] flex-col items-center justify-center gap-4 text-center px-4">
+            <p className="text-red-500 font-semibold">PDF를 불러올 수 없습니다.</p>
+            <p className="text-sm text-text-subtle">
+              접근 권한이 없거나 파일이 존재하지 않을 수 있습니다.
+            </p>
+            <div className="flex items-center gap-2">
+              <Button variant="primary" size="sm" onClick={() => window.open(pdfUrl, "_blank")}>
+                새 창에서 열기
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setHasError(false);
+                  setIsLoading(true);
+                }}
+              >
+                다시 시도
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <iframe
+            src={`${pdfUrl}#toolbar=1&navpanes=1&scrollbar=1`}
+            className="w-full h-[600px] border-0"
+            title="PDF Viewer"
+            onLoad={handleIframeLoad}
+            onError={handleIframeError}
+          />
+        )}
+      </div>
+      <div className="flex items-center justify-center gap-2 text-sm text-text-subtle">
+        <Button variant="ghost" size="sm" onClick={() => window.open(pdfUrl, "_blank")}>
+          새 창에서 열기
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            const link = document.createElement("a");
+            link.href = pdfUrl;
+            link.download = "document.pdf";
+            link.click();
+          }}
+        >
+          다운로드
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/company/safety/safety-document-modal.tsx
+++ b/src/components/features/company/safety/safety-document-modal.tsx
@@ -21,7 +21,7 @@ export function SafetyDocumentModal({
   title,
   subtitle,
   pdfUrl,
-  downloadLabel = "다운로드",
+  downloadLabel = "새 창에서 열기",
   onDownload,
 }: SafetyDocumentModalProps) {
   const handleDownload = () => {
@@ -54,7 +54,7 @@ export function SafetyDocumentModal({
       }}
     >
       <div className="flex flex-col gap-4">
-        <div className="flex items-start justify-between">
+        <div className="flex items-start justify-between mr-8">
           <div>
             <p className="!mb-0 text-2xl font-semibold text-brand-primary-strong">{title}</p>
             {subtitle && <p className="!mb-0 text-sm text-text-subtle">{subtitle}</p>}

--- a/src/components/features/company/safety/safety-document-modal.tsx
+++ b/src/components/features/company/safety/safety-document-modal.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Modal } from "antd";
+
+import { Button } from "@/components/ui/Button/button";
+import { PDFViewer } from "@/components/common/pdf-viewer";
+
+type SafetyDocumentModalProps = {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  subtitle?: string;
+  pdfUrl?: string;
+  downloadLabel?: string;
+  onDownload?: () => void;
+};
+
+export function SafetyDocumentModal({
+  open,
+  onClose,
+  title,
+  subtitle,
+  pdfUrl,
+  downloadLabel = "다운로드",
+  onDownload,
+}: SafetyDocumentModalProps) {
+  const handleDownload = () => {
+    if (pdfUrl && onDownload) {
+      onDownload();
+    } else if (pdfUrl) {
+      window.open(pdfUrl, "_blank");
+    }
+  };
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onCancel={handleClose}
+      footer={null}
+      centered
+      width={900}
+      classNames={{
+        content: "bg-white",
+        body: "p-6",
+      }}
+      styles={{
+        content: {
+          backgroundColor: "#ffffff",
+        },
+      }}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="!mb-0 text-2xl font-semibold text-brand-primary-strong">{title}</p>
+            {subtitle && <p className="!mb-0 text-sm text-text-subtle">{subtitle}</p>}
+          </div>
+          <div className="flex items-center gap-2">
+            {pdfUrl && (
+              <Button variant="primary" size="md" onClick={handleDownload}>
+                {downloadLabel}
+              </Button>
+            )}
+          </div>
+        </div>
+        <div className="rounded-2xl border border-border bg-bg-subtle p-4">
+          {pdfUrl ? (
+            <PDFViewer pdfUrl={pdfUrl} />
+          ) : (
+            <div className="flex h-[480px] items-center justify-center text-text-subtle">
+              PDF를 불러올 수 없습니다.
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/features/company/safety/safety-work-table.tsx
+++ b/src/components/features/company/safety/safety-work-table.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useMemo } from "react";
+import type { ColumnsType } from "antd/es/table";
+
+import { Table } from "@/components/ui/Table/table";
+import type { SafetyWorkRecord } from "@/lib/api/get-safety-work-records";
+import { cn } from "@/utils/cn";
+
+type SafetyWorkTableProps = {
+  records: SafetyWorkRecord[];
+  isLoading: boolean;
+  currentPage: number;
+  pageSize: number;
+  total?: number;
+  onPageChange: (page: number) => void;
+  onOpenSafetyDiary: (record: SafetyWorkRecord) => void;
+  onOpenWorkReport: (record: SafetyWorkRecord) => void;
+};
+
+const buttonClass = (enabled: boolean) =>
+  cn(
+    "inline-flex h-10 min-w-[72px] items-center justify-center rounded-xl border px-4 text-sm font-medium transition",
+    enabled
+      ? "border-brand-primary text-brand-primary hover:bg-brand-primary/5"
+      : "cursor-not-allowed border-border text-text-disabled",
+  );
+
+export function SafetyWorkTable({
+  records,
+  isLoading,
+  currentPage,
+  pageSize,
+  total,
+  onPageChange,
+  onOpenSafetyDiary,
+  onOpenWorkReport,
+}: SafetyWorkTableProps) {
+  const columns = useMemo<ColumnsType<SafetyWorkRecord>>(
+    () => [
+      {
+        title: "날짜",
+        dataIndex: "date",
+        key: "date",
+        align: "center",
+        render: (value: string) =>
+          new Date(value).toLocaleDateString("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          }),
+      },
+      {
+        title: "안전교육 일지 열람",
+        key: "safetyDiary",
+        align: "center",
+        render: (_, record) => (
+          <button
+            type="button"
+            onClick={() => record.safetyDiaryAvailable && onOpenSafetyDiary(record)}
+            disabled={!record.safetyDiaryAvailable}
+            className={buttonClass(record.safetyDiaryAvailable)}
+          >
+            열람
+          </button>
+        ),
+      },
+      {
+        title: "작업일보 열람",
+        key: "workReport",
+        align: "center",
+        render: (_, record) => (
+          <button
+            type="button"
+            onClick={() => record.workReportAvailable && onOpenWorkReport(record)}
+            disabled={!record.workReportAvailable}
+            className={buttonClass(record.workReportAvailable)}
+          >
+            열람
+          </button>
+        ),
+      },
+    ],
+    [onOpenSafetyDiary, onOpenWorkReport],
+  );
+
+  return (
+    <Table<SafetyWorkRecord>
+      columns={columns}
+      dataSource={records}
+      rowKey={(record) => record.id}
+      loading={isLoading}
+      pagination={{
+        current: currentPage,
+        pageSize,
+        total,
+        onChange: onPageChange,
+        position: ["bottomCenter"],
+        showSizeChanger: false,
+      }}
+      showHeaderBar={false}
+      borderedContainer={false}
+      className="rounded-2xl border border-border bg-white"
+    />
+  );
+}

--- a/src/hooks/use-safety-work-records.ts
+++ b/src/hooks/use-safety-work-records.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import {
+  getSafetyWorkRecords,
+  type GetSafetyWorkRecordsParams,
+  type GetSafetyWorkRecordsResponse,
+} from "@/lib/api/get-safety-work-records";
+
+export function useSafetyWorkRecords(params: GetSafetyWorkRecordsParams) {
+  return useQuery<GetSafetyWorkRecordsResponse>({
+    queryKey: [
+      "safety",
+      "work-records",
+      params.siteId,
+      params.year,
+      params.month,
+      params.page,
+      params.size,
+    ],
+    queryFn: () => getSafetyWorkRecords(params),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/src/lib/api/get-safety-work-records.ts
+++ b/src/lib/api/get-safety-work-records.ts
@@ -1,0 +1,111 @@
+import type {
+  GetSafetyDocumentPdfApiResponse,
+  GetSafetyWorkRecordsParams,
+  GetSafetyWorkRecordsResponse,
+  SafetyWorkDocumentsApiResponse,
+  SafetyWorkRecord,
+} from "@/types/safety-work";
+
+export async function getSafetyEducationLogPdfUrl(siteId: number, logId: number): Promise<string> {
+  const response = await fetch(`/api/documents/safety-education-logs/${logId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("안전교육일지 PDF를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetSafetyDocumentPdfApiResponse;
+
+  if (!json.success || !json.data?.url) {
+    throw new Error(json.message || "안전교육일지 PDF URL이 응답에 포함되어 있지 않습니다.");
+  }
+
+  return json.data.url;
+}
+
+export async function getWorkReportPdfUrl(siteId: number, workReportId: number): Promise<string> {
+  const response = await fetch(`/api/documents/work-reports/${workReportId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("작업일보 PDF를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetSafetyDocumentPdfApiResponse;
+
+  if (!json.success || !json.data?.url) {
+    throw new Error(json.message || "작업일보 PDF URL이 응답에 포함되어 있지 않습니다.");
+  }
+
+  return json.data.url;
+}
+
+export async function getSafetyWorkRecords({
+  siteId,
+  year,
+  month,
+  page = 1,
+  size = 20,
+}: GetSafetyWorkRecordsParams): Promise<GetSafetyWorkRecordsResponse> {
+  const queryParams = new URLSearchParams({
+    year,
+    month,
+    page: (page - 1).toString(), // API는 0부터 시작하므로 변환
+    size: size.toString(),
+  });
+
+  const response = await fetch(
+    `/api/v1/sites/${siteId}/safety-work-documents?${queryParams.toString()}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("안전/작업 문서 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as SafetyWorkDocumentsApiResponse;
+
+  if (!json.success) {
+    throw new Error(json.message || "안전/작업 문서 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const records: SafetyWorkRecord[] = json.data.content.map((item) => ({
+    id: `${item.date}-${item.safetyEducationLog?.logId || 0}-${item.workReport?.workReportId || 0}`,
+    date: item.date,
+    safetyDiaryAvailable: item.safetyEducationLog !== null,
+    workReportAvailable: item.workReport !== null,
+    safetyDiaryUrl: undefined,
+    workReportUrl: undefined,
+    safetyEducationLog: item.safetyEducationLog,
+    workReport: item.workReport,
+  }));
+
+  return {
+    summary: {
+      totalCount: json.data.totalElements,
+    },
+    records,
+    pagination: {
+      currentPage: json.data.pageNumber + 1, // API는 0부터 시작하므로 1부터 시작하도록 변환
+      totalPages: json.data.totalPages,
+      totalRecords: json.data.totalElements,
+      pageSize: json.data.pageSize,
+    },
+  };
+}

--- a/src/types/safety-work.ts
+++ b/src/types/safety-work.ts
@@ -1,0 +1,74 @@
+export type SafetyEducationLog = {
+  logId: number;
+  status: "MANAGER_SIGNING_PENDING" | "MANAGER_SIGNED" | "COMPLETED";
+  educationSubject: string;
+};
+
+export type WorkReport = {
+  workReportId: number;
+  sequence: number;
+};
+
+export type SafetyWorkDocumentContent = {
+  date: string;
+  safetyEducationLog: SafetyEducationLog | null;
+  workReport: WorkReport | null;
+};
+
+export type SafetyWorkDocumentsApiResponse = {
+  success: boolean;
+  message: string;
+  data: {
+    content: SafetyWorkDocumentContent[];
+    pageNumber: number;
+    pageSize: number;
+    totalElements: number;
+    totalPages: number;
+    first: boolean;
+    last: boolean;
+  };
+};
+
+// Frontend Types (for compatibility with existing components)
+export type SafetyWorkRecord = {
+  id: string;
+  date: string;
+  safetyDiaryAvailable: boolean;
+  workReportAvailable: boolean;
+  safetyDiaryUrl?: string;
+  workReportUrl?: string;
+  safetyEducationLog?: SafetyEducationLog | null;
+  workReport?: WorkReport | null;
+};
+
+export type GetSafetyWorkRecordsResponse = {
+  summary: {
+    totalCount: number;
+  };
+  records: SafetyWorkRecord[];
+  pagination: {
+    currentPage: number;
+    totalPages: number;
+    totalRecords: number;
+    pageSize: number;
+  };
+};
+
+export type GetSafetyWorkRecordsParams = {
+  siteId: number;
+  year: string;
+  month: string;
+  page?: number;
+  size?: number;
+};
+
+// PDF URL 가져오기
+export type GetSafetyDocumentPdfApiResponse = {
+  success: boolean;
+  message: string;
+  code?: string | null;
+  data: {
+    url: string;
+    expiresAt: string;
+  } | null;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,6 +1104,115 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/canvas-android-arm64@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-android-arm64@npm:0.1.82"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-darwin-arm64@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-darwin-arm64@npm:0.1.82"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-darwin-x64@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-darwin-x64@npm:0.1.82"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.82"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-arm64-gnu@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:0.1.82"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-arm64-musl@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:0.1.82"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.82"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-x64-gnu@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:0.1.82"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-x64-musl@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-linux-x64-musl@npm:0.1.82"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-win32-x64-msvc@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:0.1.82"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas@npm:^0.1.80, @napi-rs/canvas@npm:^0.1.81":
+  version: 0.1.82
+  resolution: "@napi-rs/canvas@npm:0.1.82"
+  dependencies:
+    "@napi-rs/canvas-android-arm64": 0.1.82
+    "@napi-rs/canvas-darwin-arm64": 0.1.82
+    "@napi-rs/canvas-darwin-x64": 0.1.82
+    "@napi-rs/canvas-linux-arm-gnueabihf": 0.1.82
+    "@napi-rs/canvas-linux-arm64-gnu": 0.1.82
+    "@napi-rs/canvas-linux-arm64-musl": 0.1.82
+    "@napi-rs/canvas-linux-riscv64-gnu": 0.1.82
+    "@napi-rs/canvas-linux-x64-gnu": 0.1.82
+    "@napi-rs/canvas-linux-x64-musl": 0.1.82
+    "@napi-rs/canvas-win32-x64-msvc": 0.1.82
+  dependenciesMeta:
+    "@napi-rs/canvas-android-arm64":
+      optional: true
+    "@napi-rs/canvas-darwin-arm64":
+      optional: true
+    "@napi-rs/canvas-darwin-x64":
+      optional: true
+    "@napi-rs/canvas-linux-arm-gnueabihf":
+      optional: true
+    "@napi-rs/canvas-linux-arm64-gnu":
+      optional: true
+    "@napi-rs/canvas-linux-arm64-musl":
+      optional: true
+    "@napi-rs/canvas-linux-riscv64-gnu":
+      optional: true
+    "@napi-rs/canvas-linux-x64-gnu":
+      optional: true
+    "@napi-rs/canvas-linux-x64-musl":
+      optional: true
+    "@napi-rs/canvas-win32-x64-msvc":
+      optional: true
+  checksum: e34280268a296c5532265bcab8fa2dcd5f801d7a22f29ebbcde47089c86f477ec8dcb6a5786384f6e657a2197138f34591fe41589f4e6d895e2dfdb3622896d0
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^0.2.11":
   version: 0.2.12
   resolution: "@napi-rs/wasm-runtime@npm:0.2.12"
@@ -2334,6 +2443,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-pdf@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@types/react-pdf@npm:7.0.0"
+  dependencies:
+    react-pdf: "*"
+  checksum: 9c53f15ed6fc99882c382dd0d14811dadd4e7bd77edd332a7985e7c5acde11b8ab0c8e0be24c57be4a5ae04479266a28fe079b5b1c48032b43f280af1bf3f15d
+  languageName: node
+  linkType: hard
+
 "@types/react@npm:^18":
   version: 18.3.27
   resolution: "@types/react@npm:18.3.27"
@@ -3239,6 +3357,7 @@ __metadata:
     "@types/node": ^20
     "@types/react": ^18
     "@types/react-dom": ^18
+    "@types/react-pdf": ^7.0.0
     "@vitejs/plugin-react": ^4.3.2
     antd: ^5.29.1
     clsx: ^2.1.1
@@ -3248,9 +3367,11 @@ __metadata:
     husky: ^9.1.4
     lint-staged: ^15.2.7
     next: 14.2.10
+    pdfjs-dist: ^5.4.394
     prettier: ^3.3.3
     react: 18.3.1
     react-dom: 18.3.1
+    react-pdf: ^10.2.0
     storybook: ^8.1.10
     tailwind-merge: ^2.5.2
     tailwindcss: ^4
@@ -3432,7 +3553,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^2.1.1":
+"clsx@npm:^2.0.0, clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
@@ -6034,7 +6155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -6102,6 +6223,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-cancellable-promise@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "make-cancellable-promise@npm:2.0.0"
+  checksum: 5020506bce073235dd14d25614c0283e4c864d6641cb3cbc9a1807c2151a685c20ce005f1805155b4e2fac6a9bbe0fa39ccb7dd2d623744c1526651f0768cbee
+  languageName: node
+  linkType: hard
+
+"make-event-props@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "make-event-props@npm:2.0.0"
+  checksum: 8ff3a08e7a48b2c8a79e983902e92ca2bd26d6f72a4bfa0b5750b3cfe437f4d034504788a2e9c3f5e4e2ecb6adad001c2fb1d38292e13d2b96f86b3d5208a54f
+  languageName: node
+  linkType: hard
+
 "make-fetch-happen@npm:^15.0.0":
   version: 15.0.3
   resolution: "make-fetch-happen@npm:15.0.3"
@@ -6148,6 +6283,18 @@ __metadata:
   version: 12.1.1
   resolution: "meow@npm:12.1.1"
   checksum: a6f3be85fbe53430ef53ab933dd790c39216eb4dbaabdbef593aa59efb40ecaa417897000175476bc33eed09e4cbce01df7ba53ba91e9a4bd84ec07024cb8914
+  languageName: node
+  linkType: hard
+
+"merge-refs@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-refs@npm:2.0.0"
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: a7f6a2eaf154e32962494114742c16ed5fd04b2aa797c749e1efe68d7ced6e22a3b53f391098e4ce50916dfb84e56a3a266f2b0ecfbbe6096ed21d366c1fb64d
   languageName: node
   linkType: hard
 
@@ -6748,6 +6895,30 @@ __metadata:
   version: 2.0.1
   resolution: "pathval@npm:2.0.1"
   checksum: 280e71cfd86bb5d7ff371fe2752997e5fa82901fcb209abf19d4457b7814f1b4a17845dfb17bd28a596ccdb0ecea178720ce23dacfa9c841f37804b700647810
+  languageName: node
+  linkType: hard
+
+"pdfjs-dist@npm:5.4.296":
+  version: 5.4.296
+  resolution: "pdfjs-dist@npm:5.4.296"
+  dependencies:
+    "@napi-rs/canvas": ^0.1.80
+  dependenciesMeta:
+    "@napi-rs/canvas":
+      optional: true
+  checksum: c91824f47fb1344ad1b2b2305eb2ef05996abeb6c429b5eec4c0e245ac9757347e79e53ba0f6bb38309bb40650d607f830befd392cfaebf447d0bed6589be33c
+  languageName: node
+  linkType: hard
+
+"pdfjs-dist@npm:^5.4.394":
+  version: 5.4.394
+  resolution: "pdfjs-dist@npm:5.4.394"
+  dependencies:
+    "@napi-rs/canvas": ^0.1.81
+  dependenciesMeta:
+    "@napi-rs/canvas":
+      optional: true
+  checksum: c5a2a31b4755ffca44e3ed2e5b697606c2a64fb2ad282e3500d99b8d11a380ab345dc42e698ca5153d7e39c1d2db878c6b9622bad21a0ee629cb31370e8a240a
   languageName: node
   linkType: hard
 
@@ -7497,6 +7668,29 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
+  languageName: node
+  linkType: hard
+
+"react-pdf@npm:*, react-pdf@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "react-pdf@npm:10.2.0"
+  dependencies:
+    clsx: ^2.0.0
+    dequal: ^2.0.3
+    make-cancellable-promise: ^2.0.0
+    make-event-props: ^2.0.0
+    merge-refs: ^2.0.0
+    pdfjs-dist: 5.4.296
+    tiny-invariant: ^1.0.0
+    warning: ^4.0.0
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 8b051d28acefbdc92415f1ac4b88077d752d01282802206fd5a2a71fbb9866567a22ef49bd76d992d0ebf318cc6be7be54bc8cd1c7eca8adad694adb7881cc49
   languageName: node
   linkType: hard
 
@@ -8411,7 +8605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.3.1, tiny-invariant@npm:^1.3.3":
+"tiny-invariant@npm:^1.0.0, tiny-invariant@npm:^1.3.1, tiny-invariant@npm:^1.3.3":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 5e185c8cc2266967984ce3b352a4e57cb89dad5a8abb0dea21468a6ecaa67cd5bb47a3b7a85d08041008644af4f667fb8b6575ba38ba5fb00b3b5068306e59fe
@@ -8831,6 +9025,15 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 7177fa03cff6a382f225290c9889a0d0e944d17eab705bcba89b58558a6f7adfa1f47e469b88f42a044a0eb40c12a1bf68b3cb42abb5295d04f9d7d4dd320837
+  languageName: node
+  linkType: hard
+
+"warning@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "warning@npm:4.0.3"
+  dependencies:
+    loose-envify: ^1.0.0
+  checksum: 4f2cb6a9575e4faf71ddad9ad1ae7a00d0a75d24521c193fa464f30e6b04027bd97aa5d9546b0e13d3a150ab402eda216d59c1d0f2d6ca60124d96cd40dfa35c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🎯 변경 사항

- **안전/작업 탭 UI 구현**
  - `company/[siteId]/safety/page.tsx`에서 상단 네비게이션(`CompanyTopNav`)과 타이틀/서브타이틀 영역 구현
  - 연/월 필터만 사용하는 `InlineDateFilters` 적용 (`hideDay` 옵션 사용)
  - "안전교육 및 작업일보" 카드 + 테이블 레이아웃 구성
  - 안전교육일지 / 작업일보 각각을 모달로 열람할 수 있는 `SafetyDocumentModal` + `PDFViewer` 연동

- **안전/작업 목록 API 연동 (`GET /v1/sites/{siteId}/safety-work-documents`)**
  - `get-safety-work-records.ts`에서 실제 백엔드 API 호출로 교체
    - 요청: `siteId`, `year`, `month`, `page`(0-base), `size`
    - 응답: `content`, `pageNumber`, `pageSize`, `totalElements`, `totalPages` 등
  - 응답을 프론트용 타입으로 매핑
    - `SafetyWorkRecord`에 `date`, `safetyDiaryAvailable`, `workReportAvailable` 등 추가
    - `SafetyEducationLog`, `WorkReport` 원본 정보도 보존
  - `useSafetyWorkRecords` 훅에서 `@tanstack/react-query`로 캐싱
    - `queryKey`: `["safety", "work-records", siteId, year, month, page, size]`
    - `staleTime` 5분, `refetchOnMount/windowFocus/reconnect` 비활성화
    - 목록 상단 새로고침 버튼으로만 `refetch` 수행

- **안전교육일지 / 작업일보 PDF 뷰어 연동**
  - 공통 PDF 뷰어 컴포넌트 `PDFViewer`를 `src/components/common/pdf-viewer.tsx` 에 구현
    - `iframe` 기반 미리보기
    - 로딩 오버레이 / 에러 메시지 처리
    - 브라우저 기본 PDF 툴바(저장, 인쇄 등) 활용
  - `SafetyDocumentModal`에서 `PDFViewer`를 사용해 모달 내 미리보기 제공
    - 상단에 "새 창에서 열기" 버튼만 노출 (내장 다운로드 버튼 제거)
    - 모달 배경/타이포그래피를 디자인에 맞게 조정 (흰색 배경, margin 제거 등)

- **PDF Signed URL API 연동**
  - 타입 정의 분리: `src/types/safety-work.ts`
    - `SafetyEducationLog` (`status: "MANAGER_SIGNING_PENDING" | "MANAGER_SIGNED" | "COMPLETED"`)
    - `WorkReport`, `SafetyWorkRecord`, `GetSafetyWorkRecordsResponse`, `GetSafetyDocumentPdfApiResponse` 등
  - 안전교육일지 PDF URL 조회  
    - `GET /documents/safety-education-logs/{logId}`
    - `getSafetyEducationLogPdfUrl`에서 응답(`{ success, message, data: { url, expiresAt } }`) 파싱 후 `url` 반환
  - 작업일보 PDF URL 조회  
    - `GET /documents/work-reports/{workReportId}`
    - `getWorkReportPdfUrl`에서 동일한 형태로 `url` 반환
  - `company/[siteId]/safety/page.tsx`에서 tanstack-query로 PDF URL 별도 조회
    - 안전교육일지: `queryKey: ["safety-education-log-pdf", siteId, logId]`
    - 작업일보: `queryKey: ["work-report-pdf", siteId, workReportId]`
    - 모달이 열릴 때만 `enabled: true`로 호출
    - 응답 URL을 `SafetyDocumentModal` → `PDFViewer`로 전달

---

## 📝 사용 방법

- **접근 경로**
  - 회사 대시보드 상단 네비게이션에서 해당 현장 선택 후 **"안전/작업" 탭**으로 이동

- **필터링**
  - 상단의 연/월 셀렉트를 사용해 조회 기간을 변경
    - 연/월 변경 시 페이지는 1 페이지로 리셋
    - 새로고침 버튼(↻)으로 수동 재조회

- **목록 확인**
  - "안전교육 및 작업일보" 테이블에서 날짜별로
    - **안전교육 일지 열람** 버튼
    - **작업일보 열람** 버튼  
    를 확인할 수 있음 (데이터가 없으면 비활성화)

- **PDF 열람**
  - 안전교육일지 또는 작업일보에서 `열람` 버튼 클릭
    - 해당 항목의 `logId` 또는 `workReportId`로 Signed URL 발급 API 호출
    - 모달이 뜨고, 내부 `PDFViewer` 에서 미리보기 표시

- **PDF 다운로드 / 새 창 열기**
  - 모달 상단 우측의 **"새 창에서 열기"** 버튼 클릭
    - S3 Signed URL을 새 탭에서 열어 브라우저 기본 다운로드/인쇄 기능 사용

---

## ✅ 테스트

- [ ] 연/월 필터 변경 시 `GET /v1/sites/{siteId}/safety-work-documents`가 올바른 쿼리(`year`, `month`, `page(0-base)`, `size`)로 호출되는지 확인
- [ ] 목록 페이지네이션 동작 확인 (다른 페이지로 이동 시 API 호출, 데이터/페이지 수 일치)
- [ ] 안전교육일지 `열람` 버튼 클릭 시
  - [x] `GET /api/documents/safety-education-logs/{logId}` 호출 확인
  - [ ] 응답 `data.url`이 `PDFViewer`에 전달되어 정상 렌더링되는지 확인
- [x] 작업일보 `열람` 버튼 클릭 시
  - [ ] `GET /api/documents/work-reports/{workReportId}` 호출 확인
  - [ ] 응답 `data.url` 기반 미리보기 정상 동작 확인
- [x] PDF API에서 404 / 에러 응답 시
  - [x] 모달 내에 "PDF를 불러올 수 없습니다. 접근 권한이 없거나 파일이 존재하지 않을 수 있습니다." 문구 노출
  - [x] "새 창에서 열기" / "다시 시도" 버튼 동작 확인
- [x] tanstack-query 캐싱 동작 확인
  - [x] 동일 필터/페이지에서 탭 재진입 시 재요청 없이 캐시 사용
  - [x] 상단 새로고침 버튼 클릭 시 강제 refetch

---

## 🔗 관련 이슈

- Jira: resolves BU-195
- resolves #67 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a company safety/work tab with date-filtered records, modal PDF previews via signed URLs, React Query caching, and webpack config/deps for react-pdf/pdfjs.
> 
> - **UI/Pages**:
>   - Implement `company/[siteId]/safety/page.tsx` with top nav, year/month filters, summary/count, refresh, and table of records.
>   - Add modal viewer `SafetyDocumentModal` using `PDFViewer` (iframe-based) for safety diary and work report PDFs.
>   - Add `SafetyWorkTable` with actions to open PDFs; pagination wired to data.
> - **Data & Hooks**:
>   - New hook `useSafetyWorkRecords` using React Query (staleTime 5m, keepPreviousData) fetching `getSafetyWorkRecords`.
>   - API utilities: `getSafetyWorkRecords`, `getSafetyEducationLogPdfUrl`, `getWorkReportPdfUrl` with response mapping and errors.
>   - Types in `src/types/safety-work.ts` for records, pagination, and PDF URL responses.
> - **Next.js Config**:
>   - Update `next.config.js` webpack: client aliases/fallbacks for `canvas`, `fs`, `path`, `crypto`; server externals for `react-pdf` and `pdfjs-dist`.
> - **Dependencies**:
>   - Add `react-pdf`, `pdfjs-dist`, and `@types/react-pdf`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 525d1d45d8eb7246c89879c04c0375ad58170480. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 안전교육 일지와 작업일보 문서를 PDF로 직접 조회 및 다운로드할 수 있는 기능 추가
* 내장된 PDF 뷰어로 문서 열람 및 새 창에서 열기 지원
* 날짜 필터링(년/월/일)과 페이지네이션을 통한 안전 작업 기록 관리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->