### PR TITLE
[BU-197, #69] 기업 사원관리 대시보드 구현

### DIFF
--- a/src/app/(company)/company/[siteId]/employee/page.tsx
+++ b/src/app/(company)/company/[siteId]/employee/page.tsx
@@ -7,10 +7,17 @@ import { SegmentedToggle } from "@/components/common/toggles/segmented-toggle";
 import { CompanyTopNav } from "@/components/features/company/company-top-nav";
 import { EmployeeDetailModal } from "@/components/features/company/employee/employee-detail-modal";
 import { EmployeeTable } from "@/components/features/company/employee/employee-table";
+import { SafetyDocumentModal } from "@/components/features/company/safety/safety-document-modal";
 import { buildCompanyNavItems } from "@/constants/company-nav";
 import { useCompanySites } from "@/hooks/use-company-sites";
+import { useEmployeeDetail } from "@/hooks/use-employee-detail";
+import { useEmployeeDocumentPdf } from "@/hooks/use-employee-document-pdf";
 import { useEmployees } from "@/hooks/use-employees";
-import type { EmploymentType, EmployeeRecord } from "@/types/employee";
+import type {
+  EmployeeContractDocument,
+  EmployeePayslipDocument,
+  EmploymentType,
+} from "@/types/employee";
 
 type Props = {
   params: {
@@ -58,7 +65,12 @@ export default function CompanyEmployeePage({ params }: Props) {
   const totalCount = employeeData?.summary.totalCount ?? 0;
   const tableLoading = isLoading || isFetching;
 
-  const [selectedEmployee, setSelectedEmployee] = useState<EmployeeRecord | null>(null);
+  const [selectedEmployeeId, setSelectedEmployeeId] = useState<number | null>(null);
+  const [openDocument, setOpenDocument] = useState<{
+    type: "contract" | "payslip";
+    id: number;
+    createdAt: string;
+  } | null>(null);
 
   const lastErrorMessageRef = useRef<string | null>(null);
 
@@ -80,6 +92,17 @@ export default function CompanyEmployeePage({ params }: Props) {
       duration: 3,
     });
   }, [isError, error]);
+
+  const { employee, contracts, payslips } = useEmployeeDetail({
+    siteId: Number(params.siteId),
+    employeeId: selectedEmployeeId,
+  });
+
+  const { pdfUrl } = useEmployeeDocumentPdf({
+    type: openDocument?.type ?? null,
+    id: openDocument?.id ?? null,
+    enabled: Boolean(openDocument),
+  });
 
   const handleSearchSubmit = () => {
     setPage(1);
@@ -153,16 +176,50 @@ export default function CompanyEmployeePage({ params }: Props) {
             pageSize={pageSize}
             total={totalRecords}
             onPageChange={(newPage) => setPage(newPage)}
-            onOpenDetail={(employee) => setSelectedEmployee(employee)}
+            onOpenDetail={(employeeId) => setSelectedEmployeeId(employeeId)}
           />
         </section>
       </div>
 
-      <EmployeeDetailModal
-        open={Boolean(selectedEmployee)}
-        onClose={() => setSelectedEmployee(null)}
-        employee={selectedEmployee}
-        siteName={currentSite?.siteName}
+      {selectedEmployeeId !== null && (
+        <EmployeeDetailModal
+          open={selectedEmployeeId !== null}
+          onClose={() => setSelectedEmployeeId(null)}
+          employee={employee ?? null}
+          contracts={contracts}
+          payslips={payslips}
+          siteName={currentSite?.siteName}
+          onOpenContract={(contract: EmployeeContractDocument) =>
+            setOpenDocument({
+              type: "contract",
+              id: contract.id,
+              createdAt: contract.createdAt,
+            })
+          }
+          onOpenPayslip={(payslip: EmployeePayslipDocument) =>
+            setOpenDocument({
+              type: "payslip",
+              id: payslip.id,
+              createdAt: payslip.createdAt,
+            })
+          }
+        />
+      )}
+
+      <SafetyDocumentModal
+        open={Boolean(openDocument)}
+        onClose={() => setOpenDocument(null)}
+        title={openDocument?.type === "contract" ? "근로계약서" : "급여명세서"}
+        subtitle={
+          openDocument ? `${currentSite?.siteName ?? ""} | ${openDocument.createdAt}` : undefined
+        }
+        pdfUrl={pdfUrl}
+        zIndex={2000}
+        onDownload={() => {
+          if (pdfUrl) {
+            window.open(pdfUrl, "_blank");
+          }
+        }}
       />
     </div>
   );

--- a/src/app/(company)/company/[siteId]/employee/page.tsx
+++ b/src/app/(company)/company/[siteId]/employee/page.tsx
@@ -42,6 +42,7 @@ export default function CompanyEmployeePage({ params }: Props) {
 
   const [employmentType, setEmploymentType] = useState<EmploymentType>("REGULAR");
   const [searchKeyword, setSearchKeyword] = useState("");
+  const [appliedKeyword, setAppliedKeyword] = useState<string | undefined>(undefined);
   const [page, setPage] = useState(1);
   const pageSize = 5;
 
@@ -57,7 +58,7 @@ export default function CompanyEmployeePage({ params }: Props) {
     employmentType,
     page,
     size: pageSize,
-    searchKeyword: searchKeyword.trim() || undefined,
+    searchKeyword: appliedKeyword,
   });
 
   const records = employeeData?.records ?? [];
@@ -104,7 +105,9 @@ export default function CompanyEmployeePage({ params }: Props) {
     enabled: Boolean(openDocument),
   });
 
-  const handleSearchSubmit = () => {
+  const handleSearchSubmit = (value: string) => {
+    const keyword = value.trim() || undefined;
+    setAppliedKeyword(keyword);
     setPage(1);
   };
 
@@ -144,7 +147,14 @@ export default function CompanyEmployeePage({ params }: Props) {
                   placeholder="근로자명 입력"
                   allowClear
                   value={searchKeyword}
-                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    setSearchKeyword(value);
+                    if (value === "") {
+                      setAppliedKeyword(undefined);
+                      setPage(1);
+                    }
+                  }}
                   onSearch={handleSearchSubmit}
                   enterButton="검색"
                   size="large"

--- a/src/app/(company)/company/[siteId]/employee/page.tsx
+++ b/src/app/(company)/company/[siteId]/employee/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Input, notification } from "antd";
+
+import { SegmentedToggle } from "@/components/common/toggles/segmented-toggle";
+import { CompanyTopNav } from "@/components/features/company/company-top-nav";
+import { EmployeeDetailModal } from "@/components/features/company/employee/employee-detail-modal";
+import { EmployeeTable } from "@/components/features/company/employee/employee-table";
+import { buildCompanyNavItems } from "@/constants/company-nav";
+import { useCompanySites } from "@/hooks/use-company-sites";
+import { useEmployees } from "@/hooks/use-employees";
+import type { EmploymentType, EmployeeRecord } from "@/types/employee";
+
+type Props = {
+  params: {
+    siteId: string;
+  };
+};
+
+const employmentOptions = [
+  { label: "상용직 근로자", value: "REGULAR" as EmploymentType },
+  { label: "일용직 근로자", value: "DAILY" as EmploymentType },
+];
+
+export default function CompanyEmployeePage({ params }: Props) {
+  const { data: sitesData } = useCompanySites();
+  const sites = useMemo(() => sitesData?.sites ?? [], [sitesData]);
+  const currentSite = useMemo(
+    () => sites.find((site) => String(site.siteId) === params.siteId),
+    [sites, params.siteId],
+  );
+
+  const navItems = useMemo(() => buildCompanyNavItems(params.siteId), [params.siteId]);
+
+  const [employmentType, setEmploymentType] = useState<EmploymentType>("REGULAR");
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [page, setPage] = useState(1);
+  const pageSize = 5;
+
+  const {
+    data: employeeData,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useEmployees({
+    siteId: Number(params.siteId),
+    employmentType,
+    page,
+    size: pageSize,
+    searchKeyword: searchKeyword.trim() || undefined,
+  });
+
+  const records = employeeData?.records ?? [];
+  const totalRecords = employeeData?.pagination.totalRecords ?? 0;
+  const totalCount = employeeData?.summary.totalCount ?? 0;
+  const tableLoading = isLoading || isFetching;
+
+  const [selectedEmployee, setSelectedEmployee] = useState<EmployeeRecord | null>(null);
+
+  const lastErrorMessageRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isError && !error) {
+      lastErrorMessageRef.current = null;
+      return;
+    }
+    if (!isError || !error) {
+      return;
+    }
+    const message =
+      error instanceof Error ? error.message : "사원 데이터를 불러오는 중 오류가 발생했습니다.";
+    if (lastErrorMessageRef.current === message) return;
+    lastErrorMessageRef.current = message;
+    notification.error({
+      message,
+      placement: "topRight",
+      duration: 3,
+    });
+  }, [isError, error]);
+
+  const handleSearchSubmit = () => {
+    setPage(1);
+  };
+
+  return (
+    <div className="min-h-full bg-bg-page px-4 py-6 dark:bg-dark-bg-page sm:px-6 lg:px-10 lg:py-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <div className="flex flex-col gap-4">
+          <CompanyTopNav items={navItems} defaultActiveId="employee" />
+          <header className="space-y-1">
+            <h1 className="mb-0! text-3xl font-bold! text-text-strong dark:text-dark-text-strong">
+              {currentSite?.siteName ?? "현장 이름을 불러오는 중..."}
+            </h1>
+            <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
+              사원 정보를 빠르게 조회하고 문서를 열람하세요
+            </p>
+          </header>
+        </div>
+
+        <section className="rounded-3xl border border-border bg-bg-surface px-6 py-5 dark:border-dark-border dark:bg-dark-bg-surface">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap items-center gap-3">
+              <SegmentedToggle<EmploymentType>
+                value={employmentType}
+                onChange={(val) => {
+                  setEmploymentType(val);
+                  setPage(1);
+                }}
+                options={employmentOptions}
+                className="min-w-[180px] shrink-0"
+              />
+            </div>
+
+            <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end">
+              <div className="w-full max-w-md mr-4!">
+                <Input.Search
+                  className="employee-search-input"
+                  placeholder="근로자명 입력"
+                  allowClear
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  onSearch={handleSearchSubmit}
+                  enterButton="검색"
+                  size="large"
+                />
+              </div>
+              <div className="flex items-center gap-3 text-sm text-text-subtle dark:text-dark-text-base">
+                <button
+                  type="button"
+                  onClick={() => refetch()}
+                  className="flex h-10 w-10 items-center justify-center rounded-xl border border-border text-text-subtle hover:bg-bg-subtle dark:border-dark-border dark:text-dark-text-base dark:hover:bg-dark-bg-surface"
+                >
+                  ↻
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
+          <div className="mb-4 flex items-center justify-between">
+            <p className="mb-0 text-xl font-semibold text-text-strong">사원 목록</p>
+            <p className="mb-0 text-sm text-text-subtle">총 {totalCount}명</p>
+          </div>
+
+          <EmployeeTable
+            records={records}
+            isLoading={tableLoading}
+            currentPage={page}
+            pageSize={pageSize}
+            total={totalRecords}
+            onPageChange={(newPage) => setPage(newPage)}
+            onOpenDetail={(employee) => setSelectedEmployee(employee)}
+          />
+        </section>
+      </div>
+
+      <EmployeeDetailModal
+        open={Boolean(selectedEmployee)}
+        onClose={() => setSelectedEmployee(null)}
+        employee={selectedEmployee}
+        siteName={currentSite?.siteName}
+      />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -74,3 +74,14 @@ body {
     system-ui,
     sans-serif;
 }
+
+.employee-search-input .ant-input-search-button {
+  background-color: var(--color-brand-primary);
+  border-color: var(--color-brand-primary);
+  color: var(--color-text-inverse);
+}
+
+.employee-search-input .ant-input-search-button:hover {
+  background-color: var(--color-brand-primary-strong);
+  border-color: var(--color-brand-primary-strong);
+}

--- a/src/components/features/company/employee/employee-detail-modal.tsx
+++ b/src/components/features/company/employee/employee-detail-modal.tsx
@@ -1,55 +1,36 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import { Modal, Tabs } from "antd";
 
-import { Button } from "@/components/ui/Button/button";
-import { SafetyDocumentModal } from "@/components/features/company/safety/safety-document-modal";
 import type {
   EmployeeContractDocument,
+  EmployeeDetail,
   EmployeePayslipDocument,
-  EmployeeRecord,
 } from "@/types/employee";
 
 type EmployeeDetailModalProps = {
   open: boolean;
   onClose: () => void;
-  employee: EmployeeRecord | null;
+  employee: EmployeeDetail | null;
+  contracts: EmployeeContractDocument[];
+  payslips: EmployeePayslipDocument[];
   siteName?: string;
+  onOpenContract: (contract: EmployeeContractDocument) => void;
+  onOpenPayslip: (payslip: EmployeePayslipDocument) => void;
 };
 
 export function EmployeeDetailModal({
   open,
   onClose,
   employee,
+  contracts,
+  payslips,
   siteName,
+  onOpenContract,
+  onOpenPayslip,
 }: EmployeeDetailModalProps) {
-  const [documentModal, setDocumentModal] = useState<{
-    type: "contract" | "payslip" | null;
-    document: EmployeeContractDocument | EmployeePayslipDocument | null;
-  }>({
-    type: null,
-    document: null,
-  });
-
-  const handleOpenDocument = (
-    type: "contract" | "payslip",
-    document: EmployeeContractDocument | EmployeePayslipDocument,
-  ) => {
-    setDocumentModal({ type, document });
-  };
-
-  const handleCloseDocument = () => {
-    setDocumentModal({ type: null, document: null });
-  };
-
-  if (!employee) {
-    return null;
-  }
-
-  const subtitle = `${siteName ?? ""} | ${new Date().getFullYear()}년 ${
-    new Date().getMonth() + 1
-  }월 기준`;
+  const subtitle = employee ? `${siteName ?? ""} | ${employee.joinDate} 기준` : (siteName ?? "");
 
   return (
     <>
@@ -74,14 +55,11 @@ export function EmployeeDetailModal({
           <div className="border-b border-border px-6 py-5">
             <div className="flex items-center justify-between">
               <div>
-                <p className="!mb-0 text-2xl font-semibold text-brand-primary-strong">
+                <p className="mb-0! text-2xl font-semibold text-brand-primary-strong">
                   사원 상세 정보
                 </p>
-                <p className="!mb-0 text-sm text-text-subtle">{subtitle}</p>
+                <p className="mb-0! text-sm text-text-subtle">{subtitle}</p>
               </div>
-              <Button variant="primary" size="md" onClick={onClose}>
-                닫기
-              </Button>
             </div>
           </div>
 
@@ -93,48 +71,56 @@ export function EmployeeDetailModal({
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-text-subtle">이름</span>
                   <span className="text-base font-medium text-brand-primary-strong">
-                    {employee.name}
+                    {employee?.name ?? "-"}
                   </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-text-subtle">구분</span>
                   <span className="text-base font-medium text-brand-primary-strong">
-                    {employee.employmentType === "REGULAR" ? "상용직" : "일용직"}
+                    {employee?.employmentType === "REGULAR" ? "상용직" : "일용직"}
                   </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-text-subtle">주민등록번호</span>
                   <span className="text-base text-brand-primary-strong">
-                    {employee.residentNumber}
+                    {employee?.residentNumber ?? "-"}
                   </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-text-subtle">연락처</span>
-                  <span className="text-base text-brand-primary-strong">{employee.phone}</span>
+                  <span className="text-base text-brand-primary-strong">
+                    {employee?.phone ?? "-"}
+                  </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-text-subtle">입사일</span>
-                  <span className="text-base text-brand-primary-strong">{employee.joinDate}</span>
+                  <span className="text-base text-brand-primary-strong">
+                    {employee?.joinDate ?? "-"}
+                  </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-text-subtle">퇴사일</span>
                   <span className="text-base text-brand-primary-strong">
-                    {employee.resignDate ?? "-"}
+                    {employee?.resignDate ?? "-"}
                   </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-text-subtle">이메일</span>
-                  <span className="text-base text-brand-primary-strong">{employee.email}</span>
+                  <span className="text-base text-brand-primary-strong">
+                    {employee?.email ?? "-"}
+                  </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-text-subtle">비상연락망</span>
                   <span className="text-base text-brand-primary-strong">
-                    {employee.emergencyContact}
+                    {employee?.emergencyContact ?? "-"}
                   </span>
                 </div>
                 <div className="md:col-span-2 flex items-center justify-between">
                   <span className="text-sm text-text-subtle">주소</span>
-                  <span className="text-base text-brand-primary-strong">{employee.address}</span>
+                  <span className="text-base text-brand-primary-strong">
+                    {employee?.address ?? "-"}
+                  </span>
                 </div>
               </div>
             </div>
@@ -148,8 +134,8 @@ export function EmployeeDetailModal({
                   label: "근로계약서 목록",
                   children: (
                     <EmployeeDocumentTable
-                      documents={employee.contracts}
-                      onOpen={(doc) => handleOpenDocument("contract", doc)}
+                      documents={contracts}
+                      onOpen={(doc) => onOpenContract(doc as EmployeeContractDocument)}
                     />
                   ),
                 },
@@ -158,8 +144,8 @@ export function EmployeeDetailModal({
                   label: "급여명세서 목록",
                   children: (
                     <EmployeeDocumentTable
-                      documents={employee.payslips}
-                      onOpen={(doc) => handleOpenDocument("payslip", doc)}
+                      documents={payslips}
+                      onOpen={(doc) => onOpenPayslip(doc as EmployeePayslipDocument)}
                     />
                   ),
                 },
@@ -168,23 +154,6 @@ export function EmployeeDetailModal({
           </div>
         </div>
       </Modal>
-
-      <SafetyDocumentModal
-        open={Boolean(documentModal.type && documentModal.document)}
-        onClose={handleCloseDocument}
-        title={documentModal.type === "contract" ? "근로계약서" : "급여명세서"}
-        subtitle={
-          documentModal.document
-            ? `${siteName ?? ""} | ${documentModal.document.createdAt}`
-            : undefined
-        }
-        pdfUrl={documentModal.document?.pdfUrl}
-        onDownload={() => {
-          if (documentModal.document?.pdfUrl) {
-            window.open(documentModal.document.pdfUrl, "_blank");
-          }
-        }}
-      />
     </>
   );
 }
@@ -217,7 +186,7 @@ function EmployeeDocumentTable({ documents, onOpen }: EmployeeDocumentTableProps
         <tbody>
           {documents.map((doc) => (
             <tr key={doc.id} className="border-b border-border last:border-b-0">
-              <td className="px-4 py-3 text-center text-text-strong">{doc.name}</td>
+              <td className="px-4 py-3 text-center text-text-strong">{doc.title}</td>
               <td className="px-4 py-3 text-center text-text-subtle">{doc.createdAt}</td>
               <td className="px-4 py-3 text-center">
                 <DocumentStatusPill status={doc.status} />

--- a/src/components/features/company/employee/employee-detail-modal.tsx
+++ b/src/components/features/company/employee/employee-detail-modal.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import React, { useState } from "react";
+import { Modal, Tabs } from "antd";
+
+import { Button } from "@/components/ui/Button/button";
+import { SafetyDocumentModal } from "@/components/features/company/safety/safety-document-modal";
+import type {
+  EmployeeContractDocument,
+  EmployeePayslipDocument,
+  EmployeeRecord,
+} from "@/types/employee";
+
+type EmployeeDetailModalProps = {
+  open: boolean;
+  onClose: () => void;
+  employee: EmployeeRecord | null;
+  siteName?: string;
+};
+
+export function EmployeeDetailModal({
+  open,
+  onClose,
+  employee,
+  siteName,
+}: EmployeeDetailModalProps) {
+  const [documentModal, setDocumentModal] = useState<{
+    type: "contract" | "payslip" | null;
+    document: EmployeeContractDocument | EmployeePayslipDocument | null;
+  }>({
+    type: null,
+    document: null,
+  });
+
+  const handleOpenDocument = (
+    type: "contract" | "payslip",
+    document: EmployeeContractDocument | EmployeePayslipDocument,
+  ) => {
+    setDocumentModal({ type, document });
+  };
+
+  const handleCloseDocument = () => {
+    setDocumentModal({ type: null, document: null });
+  };
+
+  if (!employee) {
+    return null;
+  }
+
+  const subtitle = `${siteName ?? ""} | ${new Date().getFullYear()}년 ${
+    new Date().getMonth() + 1
+  }월 기준`;
+
+  return (
+    <>
+      <Modal
+        open={open}
+        onCancel={onClose}
+        footer={null}
+        centered
+        width={900}
+        classNames={{
+          content: "bg-white",
+          body: "p-0",
+        }}
+        styles={{
+          content: {
+            backgroundColor: "#ffffff",
+          },
+        }}
+      >
+        <div className="flex flex-col rounded-2xl">
+          {/* Header */}
+          <div className="border-b border-border px-6 py-5">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="!mb-0 text-2xl font-semibold text-brand-primary-strong">
+                  사원 상세 정보
+                </p>
+                <p className="!mb-0 text-sm text-text-subtle">{subtitle}</p>
+              </div>
+              <Button variant="primary" size="md" onClick={onClose}>
+                닫기
+              </Button>
+            </div>
+          </div>
+
+          {/* Body */}
+          <div className="max-h-[640px] overflow-y-auto px-6 py-5">
+            {/* Basic info block */}
+            <div className="mb-6 rounded-xl border border-border bg-bg-subtle px-6 py-5">
+              <div className="grid gap-y-3 gap-x-8 md:grid-cols-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">이름</span>
+                  <span className="text-base font-medium text-brand-primary-strong">
+                    {employee.name}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">구분</span>
+                  <span className="text-base font-medium text-brand-primary-strong">
+                    {employee.employmentType === "REGULAR" ? "상용직" : "일용직"}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">주민등록번호</span>
+                  <span className="text-base text-brand-primary-strong">
+                    {employee.residentNumber}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">연락처</span>
+                  <span className="text-base text-brand-primary-strong">{employee.phone}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">입사일</span>
+                  <span className="text-base text-brand-primary-strong">{employee.joinDate}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">퇴사일</span>
+                  <span className="text-base text-brand-primary-strong">
+                    {employee.resignDate ?? "-"}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">이메일</span>
+                  <span className="text-base text-brand-primary-strong">{employee.email}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">비상연락망</span>
+                  <span className="text-base text-brand-primary-strong">
+                    {employee.emergencyContact}
+                  </span>
+                </div>
+                <div className="md:col-span-2 flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">주소</span>
+                  <span className="text-base text-brand-primary-strong">{employee.address}</span>
+                </div>
+              </div>
+            </div>
+
+            {/* Documents tabs */}
+            <Tabs
+              defaultActiveKey="contracts"
+              items={[
+                {
+                  key: "contracts",
+                  label: "근로계약서 목록",
+                  children: (
+                    <EmployeeDocumentTable
+                      documents={employee.contracts}
+                      onOpen={(doc) => handleOpenDocument("contract", doc)}
+                    />
+                  ),
+                },
+                {
+                  key: "payslips",
+                  label: "급여명세서 목록",
+                  children: (
+                    <EmployeeDocumentTable
+                      documents={employee.payslips}
+                      onOpen={(doc) => handleOpenDocument("payslip", doc)}
+                    />
+                  ),
+                },
+              ]}
+            />
+          </div>
+        </div>
+      </Modal>
+
+      <SafetyDocumentModal
+        open={Boolean(documentModal.type && documentModal.document)}
+        onClose={handleCloseDocument}
+        title={documentModal.type === "contract" ? "근로계약서" : "급여명세서"}
+        subtitle={
+          documentModal.document
+            ? `${siteName ?? ""} | ${documentModal.document.createdAt}`
+            : undefined
+        }
+        pdfUrl={documentModal.document?.pdfUrl}
+        onDownload={() => {
+          if (documentModal.document?.pdfUrl) {
+            window.open(documentModal.document.pdfUrl, "_blank");
+          }
+        }}
+      />
+    </>
+  );
+}
+
+type EmployeeDocumentTableProps = {
+  documents: (EmployeeContractDocument | EmployeePayslipDocument)[];
+  onOpen: (document: EmployeeContractDocument | EmployeePayslipDocument) => void;
+};
+
+function EmployeeDocumentTable({ documents, onOpen }: EmployeeDocumentTableProps) {
+  return (
+    <div className="mt-4 rounded-xl border border-border">
+      <table className="w-full table-fixed text-sm">
+        <thead className="bg-[#f0f6fb]">
+          <tr>
+            <th className="border-b border-border px-4 py-3 text-center font-normal text-brand-primary-strong">
+              문서명
+            </th>
+            <th className="border-b border-border px-4 py-3 text-center font-normal text-brand-primary-strong">
+              작성일
+            </th>
+            <th className="border-b border-border px-4 py-3 text-center font-normal text-brand-primary-strong">
+              상태
+            </th>
+            <th className="border-b border-border px-4 py-3 text-center font-normal text-brand-primary-strong">
+              열람
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {documents.map((doc) => (
+            <tr key={doc.id} className="border-b border-border last:border-b-0">
+              <td className="px-4 py-3 text-center text-text-strong">{doc.name}</td>
+              <td className="px-4 py-3 text-center text-text-subtle">{doc.createdAt}</td>
+              <td className="px-4 py-3 text-center">
+                <DocumentStatusPill status={doc.status} />
+              </td>
+              <td className="px-4 py-3 text-center">
+                <button
+                  type="button"
+                  onClick={() => onOpen(doc)}
+                  className="inline-flex h-8 min-w-[54px] items-center justify-center rounded-lg border border-brand-primary px-3 text-xs font-medium text-brand-primary hover:bg-brand-primary/5"
+                >
+                  열람
+                </button>
+              </td>
+            </tr>
+          ))}
+          {documents.length === 0 && (
+            <tr>
+              <td className="px-4 py-6 text-center text-text-subtle" colSpan={4}>
+                표시할 문서가 없습니다.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+type DocumentStatusPillProps = {
+  status: EmployeeContractDocument["status"];
+};
+
+function DocumentStatusPill({ status }: DocumentStatusPillProps) {
+  if (status === "COMPLETED") {
+    return (
+      <span className="inline-flex items-center rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700">
+        완료
+      </span>
+    );
+  }
+
+  if (status === "ONGOING") {
+    return (
+      <span className="inline-flex items-center rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
+        진행중
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center rounded-full bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700">
+      초안
+    </span>
+  );
+}

--- a/src/components/features/company/employee/employee-detail-modal.tsx
+++ b/src/components/features/company/employee/employee-detail-modal.tsx
@@ -77,7 +77,7 @@ export function EmployeeDetailModal({
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-text-subtle">구분</span>
                   <span className="text-base font-medium text-brand-primary-strong">
-                    {employee?.employmentType === "REGULAR" ? "상용직" : "일용직"}
+                    {employee ? (employee.employmentType === "REGULAR" ? "상용직" : "일용직") : "-"}
                   </span>
                 </div>
                 <div className="flex items-center justify-between">

--- a/src/components/features/company/employee/employee-table.tsx
+++ b/src/components/features/company/employee/employee-table.tsx
@@ -11,7 +11,7 @@ type EmployeeTableProps = {
   pageSize: number;
   total?: number;
   onPageChange: (page: number) => void;
-  onOpenDetail: (employee: EmployeeRecord) => void;
+  onOpenDetail: (employeeId: number) => void;
 };
 
 const buttonClass = (enabled: boolean) =>
@@ -49,7 +49,7 @@ export function EmployeeTable({
       key: "detail",
       align: "center",
       render: (_, record) => (
-        <button type="button" onClick={() => onOpenDetail(record)} className={buttonClass(true)}>
+        <button type="button" onClick={() => onOpenDetail(record.id)} className={buttonClass(true)}>
           열람
         </button>
       ),

--- a/src/components/features/company/employee/employee-table.tsx
+++ b/src/components/features/company/employee/employee-table.tsx
@@ -1,0 +1,78 @@
+import type { ColumnsType } from "antd/es/table";
+
+import { Table } from "@/components/ui/Table/table";
+import type { EmployeeRecord } from "@/types/employee";
+import { cn } from "@/utils/cn";
+
+type EmployeeTableProps = {
+  records: EmployeeRecord[];
+  isLoading: boolean;
+  currentPage: number;
+  pageSize: number;
+  total?: number;
+  onPageChange: (page: number) => void;
+  onOpenDetail: (employee: EmployeeRecord) => void;
+};
+
+const buttonClass = (enabled: boolean) =>
+  cn(
+    "inline-flex h-10 min-w-[72px] items-center justify-center rounded-xl border px-4 text-sm font-medium transition",
+    enabled
+      ? "border-brand-primary text-brand-primary hover:bg-brand-primary/5"
+      : "cursor-not-allowed border-border text-text-disabled",
+  );
+
+export function EmployeeTable({
+  records,
+  isLoading,
+  currentPage,
+  pageSize,
+  total,
+  onPageChange,
+  onOpenDetail,
+}: EmployeeTableProps) {
+  const columns: ColumnsType<EmployeeRecord> = [
+    {
+      title: "사원명",
+      dataIndex: "name",
+      key: "name",
+      align: "center",
+    },
+    {
+      title: "주민등록번호",
+      dataIndex: "residentNumber",
+      key: "residentNumber",
+      align: "center",
+    },
+    {
+      title: "상세 보기",
+      key: "detail",
+      align: "center",
+      render: (_, record) => (
+        <button type="button" onClick={() => onOpenDetail(record)} className={buttonClass(true)}>
+          열람
+        </button>
+      ),
+    },
+  ];
+
+  return (
+    <Table<EmployeeRecord>
+      columns={columns}
+      dataSource={records}
+      rowKey={(record) => record.id}
+      loading={isLoading}
+      pagination={{
+        current: currentPage,
+        pageSize,
+        total,
+        onChange: onPageChange,
+        position: ["bottomCenter"],
+        showSizeChanger: false,
+      }}
+      showHeaderBar={false}
+      borderedContainer={false}
+      className="rounded-2xl border border-border bg-white dark:border-dark-border dark:bg-dark-bg-surface"
+    />
+  );
+}

--- a/src/components/features/company/payroll/payroll-table.tsx
+++ b/src/components/features/company/payroll/payroll-table.tsx
@@ -101,7 +101,7 @@ const payrollColumns: ColumnsType<PayrollRecord> = [
             "inline-flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-semibold transition",
             disabled
               ? "cursor-not-allowed bg-gray-100 text-gray-400"
-              : "bg-[#1C67B0] !text-white hover:bg-[#155089]",
+              : "bg-[#1C67B0] text-white! hover:bg-[#155089]",
           )}
         >
           <span

--- a/src/components/features/company/safety/safety-document-modal.tsx
+++ b/src/components/features/company/safety/safety-document-modal.tsx
@@ -13,6 +13,7 @@ type SafetyDocumentModalProps = {
   pdfUrl?: string;
   downloadLabel?: string;
   onDownload?: () => void;
+  zIndex?: number;
 };
 
 export function SafetyDocumentModal({
@@ -23,6 +24,7 @@ export function SafetyDocumentModal({
   pdfUrl,
   downloadLabel = "새 창에서 열기",
   onDownload,
+  zIndex,
 }: SafetyDocumentModalProps) {
   const handleDownload = () => {
     if (pdfUrl && onDownload) {
@@ -43,6 +45,7 @@ export function SafetyDocumentModal({
       footer={null}
       centered
       width={900}
+      zIndex={zIndex}
       classNames={{
         content: "bg-white",
         body: "p-6",

--- a/src/hooks/use-employee-detail.ts
+++ b/src/hooks/use-employee-detail.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getEmployeeContracts,
+  getEmployeeDetail,
+  getEmployeePayslips,
+} from "@/lib/api/get-employees";
+import type {
+  EmployeeContractDocument,
+  EmployeeDetail,
+  EmployeePayslipDocument,
+} from "@/types/employee";
+
+type UseEmployeeDetailParams = {
+  siteId: number;
+  employeeId: number | null;
+};
+
+export function useEmployeeDetail({ siteId, employeeId }: UseEmployeeDetailParams) {
+  const enabled = employeeId != null;
+
+  const { data: employee } = useQuery<EmployeeDetail | null>({
+    queryKey: ["employee", "detail", siteId, employeeId],
+    queryFn: () =>
+      employeeId != null ? getEmployeeDetail({ siteId, employeeId }) : Promise.resolve(null),
+    enabled,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const { data: contractsData } = useQuery({
+    queryKey: ["employee", "contracts", siteId, employeeId],
+    queryFn: () =>
+      getEmployeeContracts({
+        siteId,
+        employeeId: employeeId!,
+      }),
+    enabled,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const { data: payslipsData } = useQuery({
+    queryKey: ["employee", "payslips", siteId, employeeId],
+    queryFn: () =>
+      getEmployeePayslips({
+        siteId,
+        employeeId: employeeId!,
+      }),
+    enabled,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const contracts: EmployeeContractDocument[] = contractsData?.contracts ?? [];
+  const payslips: EmployeePayslipDocument[] = payslipsData?.payslips ?? [];
+
+  return {
+    employee,
+    contracts,
+    payslips,
+  };
+}

--- a/src/hooks/use-employee-document-pdf.ts
+++ b/src/hooks/use-employee-document-pdf.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getContractPdfUrl, getPayslipPdfUrl } from "@/lib/api/get-employees";
+
+type UseEmployeeDocumentPdfParams = {
+  type: "contract" | "payslip" | null;
+  id: number | null;
+  enabled?: boolean;
+};
+
+export function useEmployeeDocumentPdf({ type, id, enabled = true }: UseEmployeeDocumentPdfParams) {
+  const { data: pdfUrl } = useQuery({
+    queryKey: ["employee-document-pdf", type, id],
+    queryFn: () =>
+      type === "contract" ? getContractPdfUrl(id as number) : getPayslipPdfUrl(id as number),
+    enabled: enabled && !!type && !!id,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  return { pdfUrl };
+}

--- a/src/hooks/use-employees.ts
+++ b/src/hooks/use-employees.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { getEmployeeList } from "@/lib/api/get-employees";
+import type { GetEmployeeListParams, GetEmployeeListResponse } from "@/types/employee";
+
+export function useEmployees(params: GetEmployeeListParams) {
+  return useQuery<GetEmployeeListResponse>({
+    queryKey: [
+      "employees",
+      "list",
+      params.siteId,
+      params.employmentType,
+      params.page,
+      params.size,
+      params.searchKeyword,
+    ],
+    queryFn: () => getEmployeeList(params),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/src/lib/api/get-employees.ts
+++ b/src/lib/api/get-employees.ts
@@ -1,0 +1,314 @@
+import type {
+  EmployeeContractDocument,
+  EmployeeDetail,
+  EmployeePayslipDocument,
+  EmployeeRecord,
+  GetEmployeeDetailParams,
+  GetEmployeeDocumentPdfApiResponse,
+  GetEmployeeListParams,
+  GetEmployeeListResponse,
+  GetEmployeeContractsParams,
+  GetEmployeePayslipsParams,
+  GetEmployeeContractsResponse,
+  GetEmployeePayslipsResponse,
+  EmploymentType,
+} from "@/types/employee";
+
+type EmployeeListApiResponse = {
+  success: boolean;
+  message: string;
+  code: string;
+  data: {
+    totalCount: number;
+    page: number;
+    size: number;
+    data: {
+      employeeId: number;
+      name: string;
+      residentId: string;
+      empType: string;
+    }[];
+  };
+};
+
+type EmployeeDetailApiPayload = {
+  employeeId: number;
+  name: string;
+  residentId: string;
+  empType: string;
+  phone: string;
+  email: string;
+  address: string;
+  emergencyContact: string;
+  joinedAt: string;
+  leftAt: string | null;
+};
+
+type EmployeeDetailApiResponse =
+  | EmployeeDetailApiPayload
+  | {
+      success: boolean;
+      message: string;
+      data?: EmployeeDetailApiPayload;
+    };
+
+type EmployeeContractsApiPayload = {
+  employeeId: number;
+  contracts: {
+    contractId: number;
+    title: string;
+    createdAt: string;
+    status: string;
+  }[];
+};
+
+type EmployeeContractsApiResponse =
+  | EmployeeContractsApiPayload
+  | {
+      success: boolean;
+      message: string;
+      data?: EmployeeContractsApiPayload;
+    };
+
+type EmployeePayslipsApiPayload = {
+  employeeId: number;
+  payslips: {
+    payrollId: number;
+    title: string;
+    createdAt: string;
+    status: string;
+  }[];
+};
+
+type EmployeePayslipsApiResponse =
+  | EmployeePayslipsApiPayload
+  | {
+      success: boolean;
+      message: string;
+      data?: EmployeePayslipsApiPayload;
+    };
+
+function mapEmploymentTypeToQuery(type: EmploymentType): "DAILY" | "PERMANENT" {
+  return type === "REGULAR" ? "PERMANENT" : "DAILY";
+}
+
+function mapEmploymentTypeFromApi(empType: string): EmploymentType {
+  return empType === "PERMANENT" ? "REGULAR" : "DAILY";
+}
+
+export async function getEmployeeList(
+  params: GetEmployeeListParams,
+): Promise<GetEmployeeListResponse> {
+  const queryParams = new URLSearchParams({
+    empType: mapEmploymentTypeToQuery(params.employmentType),
+    page: String(params.page),
+    size: String(params.size),
+  });
+
+  if (params.searchKeyword) {
+    queryParams.set("name", params.searchKeyword);
+  }
+
+  const response = await fetch(`/api/sites/${params.siteId}/employees?${queryParams.toString()}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("사원 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as EmployeeListApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "사원 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const records: EmployeeRecord[] = json.data.data.map((item) => ({
+    id: item.employeeId,
+    name: item.name,
+    residentNumber: item.residentId,
+    employmentType: mapEmploymentTypeFromApi(item.empType),
+  }));
+
+  const totalCount = json.data.totalCount;
+  const page = json.data.page;
+  const size = json.data.size;
+  const totalPages = Math.max(1, Math.ceil(totalCount / size));
+
+  return {
+    summary: {
+      totalCount,
+    },
+    records,
+    pagination: {
+      currentPage: page,
+      totalPages,
+      totalRecords: totalCount,
+      pageSize: size,
+    },
+  };
+}
+
+export async function getEmployeeDetail({
+  siteId,
+  employeeId,
+}: GetEmployeeDetailParams): Promise<EmployeeDetail> {
+  const response = await fetch(`/api/sites/${siteId}/employees/${employeeId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("사원 상세 정보를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const raw = (await response.json()) as EmployeeDetailApiResponse;
+
+  const payload: EmployeeDetailApiPayload | undefined = "success" in raw ? raw.data : raw;
+
+  if (!payload) {
+    const message =
+      "success" in raw ? raw.message : "사원 상세 정보를 불러오는 중 오류가 발생했습니다.";
+    throw new Error(message);
+  }
+
+  return {
+    id: payload.employeeId,
+    name: payload.name,
+    residentNumber: payload.residentId,
+    employmentType: mapEmploymentTypeFromApi(payload.empType),
+    phone: payload.phone,
+    email: payload.email,
+    address: payload.address,
+    emergencyContact: payload.emergencyContact,
+    joinDate: payload.joinedAt,
+    resignDate: payload.leftAt || undefined,
+  };
+}
+
+export async function getEmployeeContracts({
+  siteId,
+  employeeId,
+}: GetEmployeeContractsParams): Promise<GetEmployeeContractsResponse> {
+  const response = await fetch(`/api/sites/${siteId}/employees/${employeeId}/contracts`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("근로계약서 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const raw = (await response.json()) as EmployeeContractsApiResponse;
+  const payload: EmployeeContractsApiPayload | undefined = "success" in raw ? raw.data : raw;
+
+  if (!payload) {
+    const message =
+      "success" in raw ? raw.message : "근로계약서 목록을 불러오는 중 오류가 발생했습니다.";
+    throw new Error(message);
+  }
+
+  const contracts: EmployeeContractDocument[] = payload.contracts.map((item) => ({
+    id: item.contractId,
+    title: item.title,
+    createdAt: item.createdAt,
+    status: item.status,
+  }));
+
+  return {
+    employeeId: payload.employeeId,
+    contracts,
+  };
+}
+
+export async function getEmployeePayslips({
+  siteId,
+  employeeId,
+}: GetEmployeePayslipsParams): Promise<GetEmployeePayslipsResponse> {
+  const response = await fetch(`/api/sites/${siteId}/employees/${employeeId}/payslips`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("급여명세서 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const raw = (await response.json()) as EmployeePayslipsApiResponse;
+  const payload: EmployeePayslipsApiPayload | undefined = "success" in raw ? raw.data : raw;
+
+  if (!payload) {
+    const message =
+      "success" in raw ? raw.message : "급여명세서 목록을 불러오는 중 오류가 발생했습니다.";
+    throw new Error(message);
+  }
+
+  const payslips: EmployeePayslipDocument[] = payload.payslips.map((item) => ({
+    id: item.payrollId,
+    title: item.title,
+    createdAt: item.createdAt,
+    status: item.status,
+  }));
+
+  return {
+    employeeId: payload.employeeId,
+    payslips,
+  };
+}
+
+export async function getContractPdfUrl(contractId: number): Promise<string> {
+  const response = await fetch(`/api/documents/contracts/${contractId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("근로계약서 PDF를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetEmployeeDocumentPdfApiResponse;
+
+  if (!json.success || !json.data?.url) {
+    throw new Error(json.message || "근로계약서 PDF URL이 응답에 포함되어 있지 않습니다.");
+  }
+
+  return json.data.url;
+}
+
+export async function getPayslipPdfUrl(payrollId: number): Promise<string> {
+  const response = await fetch(`/api/documents/payslips/${payrollId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("급여명세서 PDF를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetEmployeeDocumentPdfApiResponse;
+
+  if (!json.success || !json.data?.url) {
+    throw new Error(json.message || "급여명세서 PDF URL이 응답에 포함되어 있지 않습니다.");
+  }
+
+  return json.data.url;
+}

--- a/src/types/employee.ts
+++ b/src/types/employee.ts
@@ -1,38 +1,39 @@
 export type EmploymentType = "REGULAR" | "DAILY";
 
-export type EmployeeDocumentStatus = "DRAFT" | "ONGOING" | "COMPLETED";
-
-export type EmployeeContractDocument = {
-  id: number;
-  name: string;
-  createdAt: string;
-  status: EmployeeDocumentStatus;
-  pdfUrl?: string;
-};
-
-export type EmployeePayslipDocument = {
-  id: number;
-  name: string;
-  createdAt: string;
-  status: EmployeeDocumentStatus;
-  pdfUrl?: string;
-};
-
 export type EmployeeRecord = {
   id: number;
-  siteId: number;
   name: string;
   residentNumber: string;
   employmentType: EmploymentType;
-  joinDate: string;
-  resignDate?: string;
+};
+
+export type EmployeeDetail = {
+  id: number;
+  name: string;
+  residentNumber: string;
+  employmentType: EmploymentType;
   phone: string;
   email: string;
   address: string;
   emergencyContact: string;
-  emergencyContactName?: string;
-  contracts: EmployeeContractDocument[];
-  payslips: EmployeePayslipDocument[];
+  joinDate: string;
+  resignDate?: string;
+};
+
+export type EmployeeDocumentStatus = "DRAFT" | "ONGOING" | "COMPLETED" | string;
+
+export type EmployeeContractDocument = {
+  id: number;
+  title: string;
+  createdAt: string;
+  status: EmployeeDocumentStatus;
+};
+
+export type EmployeePayslipDocument = {
+  id: number;
+  title: string;
+  createdAt: string;
+  status: EmployeeDocumentStatus;
 };
 
 export type GetEmployeeListParams = {
@@ -56,4 +57,38 @@ export type GetEmployeeListResponse = {
   };
   records: EmployeeRecord[];
   pagination: EmployeeListPagination;
+};
+
+export type GetEmployeeDetailParams = {
+  siteId: number;
+  employeeId: number;
+};
+
+export type GetEmployeeContractsParams = {
+  siteId: number;
+  employeeId: number;
+};
+
+export type GetEmployeePayslipsParams = {
+  siteId: number;
+  employeeId: number;
+};
+
+export type GetEmployeeContractsResponse = {
+  employeeId: number;
+  contracts: EmployeeContractDocument[];
+};
+
+export type GetEmployeePayslipsResponse = {
+  employeeId: number;
+  payslips: EmployeePayslipDocument[];
+};
+
+export type GetEmployeeDocumentPdfApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    url: string;
+    expiresAt: string;
+  };
 };

--- a/src/types/employee.ts
+++ b/src/types/employee.ts
@@ -1,0 +1,59 @@
+export type EmploymentType = "REGULAR" | "DAILY";
+
+export type EmployeeDocumentStatus = "DRAFT" | "ONGOING" | "COMPLETED";
+
+export type EmployeeContractDocument = {
+  id: number;
+  name: string;
+  createdAt: string;
+  status: EmployeeDocumentStatus;
+  pdfUrl?: string;
+};
+
+export type EmployeePayslipDocument = {
+  id: number;
+  name: string;
+  createdAt: string;
+  status: EmployeeDocumentStatus;
+  pdfUrl?: string;
+};
+
+export type EmployeeRecord = {
+  id: number;
+  siteId: number;
+  name: string;
+  residentNumber: string;
+  employmentType: EmploymentType;
+  joinDate: string;
+  resignDate?: string;
+  phone: string;
+  email: string;
+  address: string;
+  emergencyContact: string;
+  emergencyContactName?: string;
+  contracts: EmployeeContractDocument[];
+  payslips: EmployeePayslipDocument[];
+};
+
+export type GetEmployeeListParams = {
+  siteId: number;
+  employmentType: EmploymentType;
+  page: number;
+  size: number;
+  searchKeyword?: string;
+};
+
+export type EmployeeListPagination = {
+  currentPage: number;
+  totalPages: number;
+  totalRecords: number;
+  pageSize: number;
+};
+
+export type GetEmployeeListResponse = {
+  summary: {
+    totalCount: number;
+  };
+  records: EmployeeRecord[];
+  pagination: EmployeeListPagination;
+};


### PR DESCRIPTION
## 🎯 변경 사항

- **사원 관리 탭 UI 구현 (기업 대시보드)**
  - `상용직 근로자 / 일용직 근로자` 토글(공통 `SegmentedToggle`)과 **근로자명 검색 인풋**으로 구성된 상단 필터 영역 구현.
  - 사원 목록 카드: `"사원 목록"` 헤더 + 우측 `"총 N명"` 카운트, 테이블 컬럼은 `사원명 / 주민등록번호 / 상세 보기` 로 구성.
  - 테이블 하단 중앙 페이지네이션 적용, pageSize는 5로 설정해 Figma에 맞는 밀도 유지.

- **사원 목록 API 연동 (`GET /sites/{siteId}/employees`)**
  - `src/lib/api/get-employees.ts`에서 `getEmployeeList` 구현:
    - `empType` 쿼리로 상용직(`PERMANENT`) / 일용직(`DAILY`) 분기, `name`, `page`, `size`를 함께 전달.
    - 응답의 `data.data` 배열을 `EmployeeRecord`로 매핑 (`employeeId`, `name`, `residentId`, `empType` → id, name, residentNumber, employmentType).
    - `totalCount`, `page`, `size` 기반으로 페이지네이션 정보 계산.
  - `src/types/employee.ts`에 목록/상세/문서/페이지네이션 타입 정의 (`EmployeeRecord`, `EmployeeDetail`, `EmployeeContractDocument`, `EmployeePayslipDocument`, `GetEmployeeListResponse` 등).
  - `src/hooks/use-employees.ts`에서 tanstack-query 기반 `useEmployees` 훅 구현:
    - `["employees","list", siteId, empType, page, size, searchKeyword]`를 queryKey로 사용.
    - `staleTime = 5분`, `refetchOnMount/windowFocus/reconnect = false`, `placeholderData: keepPreviousData`로 캐싱/UX 튜닝.

- **사원 상세/계약서/급여명세서 API 연동 및 분리된 훅**
  - 상세 정보:
    - `GET /sites/{siteId}/employees/{employeeId}`를 호출하는 `getEmployeeDetail` 구현.
    - API 응답의 `employeeId`, `residentId`, `empType`, `joinedAt`, `leftAt` 등을 `EmployeeDetail`로 매핑.
  - 근로계약서 목록:
    - `GET /sites/{siteId}/employees/{employeeId}/contracts` → `getEmployeeContracts`.
    - 응답의 `contractId`, `title`, `createdAt`, `status`를 `EmployeeContractDocument`로 매핑.
  - 급여명세서 목록:
    - `GET /sites/{siteId}/employees/{employeeId}/payslips` → `getEmployeePayslips`.
    - 응답의 `payrollId`, `title`, `createdAt`, `status`를 `EmployeePayslipDocument`로 매핑.
  - 위 3개를 통합하는 상세용 훅 `src/hooks/use-employee-detail.ts` 구현:
    - `useEmployeeDetail({ siteId, employeeId })`에서 `employee`, `contracts`, `payslips`를 각각 별도 queryKey로 패칭.
    - 모든 쿼리에 `staleTime = 5분` 적용, `employeeId`가 없을 때는 비활성화.

- **문서 PDF 뷰어 API 연동 (계약서/급여명세서)**
  - 계약서: `GET /documents/contracts/{contractId}` → `getContractPdfUrl`.
  - 급여명세서: `GET /documents/payslips/{payrollId}` → `getPayslipPdfUrl`.
  - 응답의 `{ success, message, data: { url, expiresAt } }`에서 `url`만 추출해 뷰어에 전달.
  - 공통 훅 `src/hooks/use-employee-document-pdf.ts` 추가:
    - `useEmployeeDocumentPdf({ type, id })`로 문서 종류별 PDF URL을 tanstack-query로 캐시.

- **사원 상세 모달 UI & 책임 분리**
  - `src/components/features/company/employee/employee-detail-modal.tsx`는 **순수 프레젠테이션 컴포넌트**로 분리:
    - Props: `employee`, `contracts`, `payslips`, `onOpenContract`, `onOpenPayslip`.
    - 상단에 `"사원 상세 정보"` + `{현장명 | 입사일 기준}` 서브타이틀, Figma에 맞는 기본 정보 그리드(이름, 구분, 주민등록번호, 연락처, 이메일, 주소, 비상연락망, 입/퇴사일) 구현.
    - 하단 Tabs로 `근로계약서 목록 / 급여명세서 목록`을 표시하고, 각 행 `"열람"` 버튼 클릭 시 상위에서 전달된 콜백만 호출.
  - 페이지(`src/app/(company)/company/[siteId]/employee/page.tsx`)에서만:
    - `useEmployees`로 목록, `useEmployeeDetail`로 상세/문서 목록, `useEmployeeDocumentPdf`로 PDF URL을 관리.
    - `selectedEmployeeId`와 `openDocument({ type, id, createdAt })` 상태를 두고, 상세 모달과 PDF 뷰어 모달을 모두 **상위 레벨에서 제어**.

- **PDF 뷰어 모달 재사용 및 z-index 조정**
  - 기존 안전/작업에서 사용하던 `SafetyDocumentModal`을 그대로 재사용해 계약서/급여명세서 뷰어로 활용.
  - `SafetyDocumentModal`에 `zIndex` props를 추가하고, 사원 관리 페이지에서 사용하는 경우 `zIndex={2000}`으로 설정해 **상세 모달 위 레이어에서** PDF 뷰어가 뜨도록 조정.

- **기타 UI/스타일 정리**
  - 검색 인풋(`Input.Search`)에 `employee-search-input` 클래스를 부여하고, `globals.css`에서 `.ant-input-search-button` 색상을 브랜드 primary로 오버라이드.
  - Tailwind 클래스 정리 (`!mb-0` → `mb-0!`, `!text-white` → `text-white!`)로 lint 경고 제거.

---

## 📝 사용 방법

- **사원 목록 조회**
  1. 기업 대시보드에서 특정 현장으로 진입 후, 상단 탭에서 **사원 관리**를 선택합니다.
  2. 상단 필터:
     - 왼쪽 토글에서 **상용직 근로자 / 일용직 근로자**를 선택하면 `empType`이 바뀌며 목록이 필터링됩니다.
     - 오른쪽 검색 인풋에 **근로자명**을 입력 후 엔터 또는 검색 버튼을 누르면 `name` 쿼리로 필터링됩니다.
  3. 테이블 하단 페이지네이션으로 페이지 이동 (한 페이지당 5명).

- **사원 상세 정보 확인**
  1. 목록 테이블의 `"상세 보기"` 열에서 `"열람"` 버튼을 클릭합니다.
  2. **사원 상세 모달**이 열리며, 상단에는 기본 정보(이름, 구분, 주민번호, 연락처, 이메일, 주소, 비상연락망, 입/퇴사일)가 Figma에 맞게 2열 그리드로 표시됩니다.
  3. 하단 탭:
     - `근로계약서 목록` 탭: 문서명, 작성일, 상태, 열람 버튼 확인.
     - `급여명세서 목록` 탭: 동일한 형식으로 급여명세서 목록 확인.

- **근로계약서 / 급여명세서 PDF 열람**
  1. 사원 상세 모달의 문서 목록에서 `"열람"` 버튼을 클릭합니다.
  2. 기존 안전/작업에서 사용하던 **PDF 뷰어 모달**이 상위 레이어에서 열리며, 브라우저의 PDF 뷰어(iframe)를 통해 S3 Signed URL을 사용해 내용을 미리보기 할 수 있습니다.
  3. 모달 내 `"새 창에서 열기"` 버튼을 클릭하면 동일 URL이 새 탭에서 열려 브라우저 기본 PDF 기능(다운로드 포함)을 사용할 수 있습니다.

---

## ✅ 테스트

- [x] **사원 목록**
  - [x] 상용직/일용직 토글 및 근로자명 검색 시, `GET /sites/{siteId}/employees`에 `empType`, `name`, `page`, `size`가 기대대로 전달되는지 Network 탭으로 확인.
  - [x] pageSize=5 설정 후, 페이지 이동 시 쿼리의 `page` 파라미터와 테이블 렌더링이 일치하는지 확인.
- [x] **사원 상세 모달**
  - [x] `"상세 보기"` 버튼 클릭 시 `GET /sites/{siteId}/employees/{employeeId}`가 호출되고, 모달의 각 필드에 값이 제대로 매핑되는지 확인.
  - [x] `근로계약서 목록 / 급여명세서 목록` 탭 전환 시, 각각 `GET /sites/{siteId}/employees/{employeeId}/contracts`, `GET /sites/{siteId}/employees/{employeeId}/payslips` 응답 내용이 테이블에 잘 반영되는지 확인.
- [x] **PDF 뷰어**
  - [ ] 계약서 `"열람"` 클릭 시 `GET /documents/contracts/{contractId}`가 호출되고, Signed URL이 iframe으로 렌더링되는지 확인.
  - [ ] 급여명세서 `"열람"` 클릭 시 `GET /documents/payslips/{payrollId}` 응답 URL로 PDF가 정상 표시되는지 확인.
  - [ ] PDF 뷰어 모달이 항상 **사원 상세 모달 위**에서 뜨는지(z-index) 시각적으로 확인.
- [x] **캐싱 동작**
  - [x] 동일 사원 상세 모달을 다시 열었을 때, tanstack-query 캐시가 사용되어 불필요한 재요청 없이 빠르게 표시되는지 확인.
  - [x] 페이지 재진입 시 사원 목록이 즉시 표시되고, 새로고침 버튼을 눌렀을 때만 refetch되는지 확인.
- [x] **lint / 타입**
  - [x] TypeScript, ESLint, Tailwind 인텔리센스 경고/에러 없는지 확인.

---

## 🔗 관련 이슈

- Jira: resolves BU-197
- resolves #69 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an employee management page with filters and table, a detail modal with contracts/payslips, and PDF viewing via new API clients and hooks.
> 
> - **UI/Pages**:
>   - Add `src/app/(company)/company/[siteId]/employee/page.tsx` with `EmploymentType` toggle, name search, refresh, paginated `EmployeeTable`.
>   - Add `EmployeeDetailModal` showing employee basics and tabs for `contracts`/`payslips` with open actions.
>   - Reuse `SafetyDocumentModal` for PDFs; add `zIndex` prop to layer above detail modal.
> - **Data/API**:
>   - Hooks: `use-employees`, `use-employee-detail`, `use-employee-document-pdf` using React Query (5m stale, preserved pagination data).
>   - API client (`src/lib/api/get-employees.ts`): `getEmployeeList`, `getEmployeeDetail`, `getEmployeeContracts`, `getEmployeePayslips`, `getContractPdfUrl`, `getPayslipPdfUrl` with type/status mappings and pagination.
> - **Types**:
>   - Define `EmploymentType`, `EmployeeRecord`, `EmployeeDetail`, `EmployeeContractDocument`, `EmployeePayslipDocument`, request/response types in `src/types/employee.ts`.
> - **Styles**:
>   - Brand styles for search button via `.employee-search-input` in `globals.css`.
>   - Minor button style tweak in `payroll-table.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b715729a0e9a9a3cad7ec999ddb4e5fbc4c3bc17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 직원 관리 페이지 추가: 사이트별 직원 목록, 고용 유형 토글(REGULAR/DAILY), 디바운스 검색, 페이지네이션 및 수동 새로고침 제공
  * 직원 상세 모달 추가: 기본 정보, 계약서·급여명세서 탭에서 문서 열람 및 다운로드 가능
  * 문서 뷰어 개선: 문서 모달의 표시 우선순위(z-index) 지원으로 겹침 문제 완화

* **스타일**
  * 검색 버튼 스타일 업데이트: 브랜드 색상 및 호버 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->