### PR TITLE
[BU-191, #59] feat: 기업 대시보드 API 연동

### DIFF
--- a/src/app/(company)/company/[siteId]/dashboard/page.tsx
+++ b/src/app/(company)/company/[siteId]/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { notification } from "antd";
 
 import { CompanyTopNav } from "@/components/features/company/company-top-nav";
 import { OverviewCard } from "@/components/features/company/dashboard/overview-card";
@@ -12,6 +13,7 @@ import { AlertCenterCard } from "@/components/features/company/dashboard/alert-c
 import type { StatusPillProps } from "@/components/ui/StatusPill/status-pill";
 import { buildCompanyNavItems } from "@/constants/company-nav";
 import { useCompanySites } from "@/hooks/use-company-sites";
+import { useSiteDashboard } from "@/hooks/use-site-dashboard";
 
 type ActivityItem = {
   id: string;
@@ -82,6 +84,50 @@ export default function CompanyDashboardPage({ params }: Props) {
 
   const navItems = useMemo(() => buildCompanyNavItems(params.siteId), [params.siteId]);
 
+  const { data: dashboard, isError, error } = useSiteDashboard(Number(params.siteId));
+
+  const lastErrorMessageRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isError && !error) {
+      lastErrorMessageRef.current = null;
+      return;
+    }
+
+    if (!isError || !error) {
+      return;
+    }
+
+    const message =
+      error instanceof Error ? error.message : "대시보드 정보를 불러오는 중 오류가 발생했습니다.";
+
+    if (lastErrorMessageRef.current === message) return;
+
+    lastErrorMessageRef.current = message;
+
+    notification.error({
+      message,
+      placement: "topRight",
+      duration: 3,
+    });
+  }, [isError, error]);
+
+  const siteName =
+    dashboard?.siteInfo.siteName ?? currentSite?.siteName ?? "현장 이름을 불러오는 중...";
+  const siteAddress =
+    dashboard?.siteInfo.siteAddress ??
+    currentSite?.siteAddress ??
+    "현장 운영 현황을 한눈에 확인하세요";
+
+  const clientName = dashboard?.siteInfo.clientName ?? "-";
+  const startDate = dashboard?.siteInfo.startDate ?? "-";
+  const endDate = dashboard?.siteInfo.endDate ?? "-";
+  const progressRate = dashboard?.siteInfo.progressRate ?? 0;
+
+  const workforce = dashboard?.workforceStatus;
+  const safety = dashboard?.safetyStatus;
+  const labor = dashboard?.laborStatus;
+
   return (
     <div className="min-h-full bg-bg-page px-4 py-6 dark:bg-dark-bg-page sm:px-6 lg:px-10 lg:py-8">
       <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
@@ -89,27 +135,40 @@ export default function CompanyDashboardPage({ params }: Props) {
           <CompanyTopNav items={navItems} defaultActiveId="dashboard" />
           <header>
             <h1 className="mb-0! text-3xl font-bold! text-text-strong dark:text-dark-text-strong">
-              {currentSite?.siteName ?? "현장 이름을 불러오는 중..."}
+              {siteName}
             </h1>
             <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
-              {currentSite?.siteAddress ?? "현장 운영 현황을 한눈에 확인하세요"}
+              {siteAddress}
             </p>
           </header>
         </div>
 
         <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
           <OverviewCard
-            client="이천시청"
-            startDate="2024.03.15"
-            endDate="2025.12.30"
-            progress={68}
+            client={clientName}
+            startDate={startDate}
+            endDate={endDate}
+            progress={progressRate}
           />
-          <WorkforceCard total={142} salaried={89} daily={53} attendanceToday={127} />
+          <WorkforceCard
+            total={workforce?.totalWorkers ?? 0}
+            salaried={workforce?.permanentWorkers ?? 0}
+            daily={workforce?.dailyWorkers ?? 0}
+            attendanceToday={workforce?.todayAttendance ?? 0}
+          />
         </section>
 
         <section className="grid gap-6 lg:grid-cols-2">
-          <LaborKpiCard />
-          <SafetyKpiCard />
+          <LaborKpiCard
+            totalPendingContracts={labor?.totalPendingContracts ?? 0}
+            pendingContracts={labor?.pendingContracts ?? []}
+          />
+          <SafetyKpiCard
+            safetyRate={safety?.safetyRate ?? 0}
+            todayWarnings={safety?.todayWarnings ?? 0}
+            incompletedEducation={safety?.incompletedEducation ?? 0}
+            completedInspections={safety?.completedInspections ?? 0}
+          />
         </section>
 
         <section className="grid gap-6 lg:grid-cols-2">

--- a/src/components/features/company/dashboard/labor-kpi-card.tsx
+++ b/src/components/features/company/dashboard/labor-kpi-card.tsx
@@ -1,8 +1,21 @@
 "use client";
 
 import { KPICard } from "@/components/features/company/dashboard/kpi-card";
+import type { PendingContract } from "@/types/dashboard";
 
-export function LaborKpiCard() {
+type LaborKpiCardProps = {
+  totalPendingContracts: number;
+  pendingContracts: PendingContract[];
+};
+
+export function LaborKpiCard({ totalPendingContracts, pendingContracts }: LaborKpiCardProps) {
+  const items =
+    pendingContracts.length > 0
+      ? pendingContracts.map((contract) => ({
+          label: `[ ${contract.contractType} ] ${contract.targetName}`,
+        }))
+      : [{ label: "미결 전자계약이 없습니다." }];
+
   return (
     <KPICard
       title="노무 현황 (KPI)"
@@ -10,14 +23,10 @@ export function LaborKpiCard() {
       highlight={{
         label: "미결 전자계약",
         description: "처리 필요",
-        value: "7건",
-        variant: "danger",
+        value: `${totalPendingContracts}건`,
+        variant: totalPendingContracts > 0 ? "danger" : "success",
       }}
-      items={[
-        { label: "[ 근로계약서 ] 박승희" },
-        { label: "[ 근로계약서 ] 김세원" },
-        { label: "[ 근로계약서 ] 문현민" },
-      ]}
+      items={items}
     />
   );
 }

--- a/src/components/features/company/dashboard/safety-kpi-card.tsx
+++ b/src/components/features/company/dashboard/safety-kpi-card.tsx
@@ -2,7 +2,19 @@
 
 import { KPICard } from "@/components/features/company/dashboard/kpi-card";
 
-export function SafetyKpiCard() {
+type SafetyKpiCardProps = {
+  safetyRate: number;
+  todayWarnings: number;
+  incompletedEducation: number;
+  completedInspections: number;
+};
+
+export function SafetyKpiCard({
+  safetyRate,
+  todayWarnings,
+  incompletedEducation,
+  completedInspections,
+}: SafetyKpiCardProps) {
   return (
     <KPICard
       title="안전 현황 (KPI)"
@@ -10,25 +22,25 @@ export function SafetyKpiCard() {
       highlight={{
         label: "안전율",
         description: "금일 기준",
-        value: "98.5%",
+        value: `${safetyRate}%`,
         variant: "success",
       }}
       items={[
         {
           label: "금일 발생 안전 경고",
-          value: "2건",
+          value: `${todayWarnings}건`,
           variant: "danger",
           icon: "warning",
         },
         {
           label: "교육 미이수",
-          value: "5명",
+          value: `${incompletedEducation}명`,
           variant: "warning",
           icon: "graduate",
         },
         {
           label: "안전 점검 완료",
-          value: "95%",
+          value: `${completedInspections}건`,
           variant: "success",
           icon: "check",
         },

--- a/src/hooks/use-site-dashboard.ts
+++ b/src/hooks/use-site-dashboard.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { getSiteDashboard } from "@/lib/api/get-dashboard";
+import type { SiteDashboard } from "@/types/dashboard";
+
+export function useSiteDashboard(siteId: number) {
+  return useQuery<SiteDashboard>({
+    queryKey: ["site", "dashboard", siteId],
+    queryFn: () => getSiteDashboard(siteId),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    placeholderData: keepPreviousData,
+    enabled: !!siteId,
+  });
+}

--- a/src/lib/api/get-dashboard.ts
+++ b/src/lib/api/get-dashboard.ts
@@ -1,0 +1,23 @@
+import type { GetSiteDashboardApiResponse, SiteDashboard } from "@/types/dashboard";
+
+export async function getSiteDashboard(siteId: number): Promise<SiteDashboard> {
+  const response = await fetch(`/api/v1/sites/${siteId}/dashboard`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("대시보드 정보를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetSiteDashboardApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "대시보드 정보를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  return json.data;
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,50 @@
+export type SiteInfo = {
+  siteId: number;
+  siteName: string;
+  siteAddress: string;
+  clientName: string;
+  startDate: string;
+  endDate: string;
+  progressRate: number;
+  managerName: string;
+};
+
+export type WorkforceStatus = {
+  totalWorkers: number;
+  permanentWorkers: number;
+  dailyWorkers: number;
+  todayAttendance: number;
+  todayLateCount: number;
+};
+
+export type SafetyStatus = {
+  safetyRate: number;
+  todayWarnings: number;
+  incompletedEducation: number;
+  completedInspections: number;
+};
+
+export type PendingContract = {
+  contractId: number;
+  contractType: string;
+  targetName: string;
+  contractState: string;
+};
+
+export type LaborStatus = {
+  totalPendingContracts: number;
+  pendingContracts: PendingContract[];
+};
+
+export type SiteDashboard = {
+  siteInfo: SiteInfo;
+  workforceStatus: WorkforceStatus;
+  safetyStatus: SafetyStatus;
+  laborStatus: LaborStatus;
+};
+
+export type GetSiteDashboardApiResponse = {
+  success: boolean;
+  message: string;
+  data: SiteDashboard;
+};


### PR DESCRIPTION
## 🎯 변경 사항

- **현장 대시보드 API 연동**
  - `GET /v1/sites/{siteId}/dashboard`를 호출하는 `getSiteDashboard` API 클라이언트 추가 (`src/lib/api/get-dashboard.ts`).
  - 대시보드 응답 스키마를 전담하는 타입 정의 추가 (`src/types/dashboard.ts`):
    - `SiteInfo`, `WorkforceStatus`, `SafetyStatus`, `PendingContract`, `LaborStatus`, `SiteDashboard`, `GetSiteDashboardApiResponse` 등.
- **tanstack/react-query 기반 대시보드 데이터 캐싱**
  - `useSiteDashboard` 훅 추가 (`src/hooks/use-site-dashboard.ts`):
    - `queryKey: ["site", "dashboard", siteId]`
    - `staleTime: 5분`, `gcTime: 30분`, `refetchOnMount/WindowFocus/Reconnect: false`, `placeholderData: keepPreviousData`로 설정해 불필요한 재호출 최소화.
- **대시보드 UI와 API 데이터 바인딩**
  - `CompanyDashboardPage`에서 대시보드 데이터 연동 (`src/app/(company)/company/[siteId]/dashboard/page.tsx`):
    - 헤더 현장명/주소를 `dashboard.siteInfo` 우선 사용, 없을 경우 `useCompanySites` 데이터로 fallback.
    - `OverviewCard`에 현장 기본 정보 바인딩:
      - `client` → `clientName`
      - `startDate` → `startDate`
      - `endDate` → `endDate`
      - `progress` → `progressRate`
    - `WorkforceCard`에 인원 현황 바인딩:
      - `total` → `totalWorkers`
      - `salaried` → `permanentWorkers`
      - `daily` → `dailyWorkers`
      - `attendanceToday` → `todayAttendance`
    - `LaborKpiCard`에 노무 현황 바인딩:
      - `totalPendingContracts` → `laborStatus.totalPendingContracts`
      - `pendingContracts` 목록을 `[ {contractType} ] {targetName}` 포맷으로 리스트화.
    - `SafetyKpiCard`에 안전 현황 바인딩:
      - `safetyRate`, `todayWarnings`, `incompletedEducation`, `completedInspections`를 KPI 항목으로 표시.
- **에러 처리 및 UX 개선**
  - `antd.notification` + `lastErrorMessageRef`를 사용해 대시보드 조회 실패 시 상단 우측에 에러 토스트 노출, 동일 에러 메시지 중복 노출 방지.
  - API 데이터가 없을 때는 기존 하드코딩 값 대신 `0`/`"-"` 등 안전한 기본값으로 표시하여 UI 깨짐 방지.

## 📝 사용 방법

- **접근 경로**
  - 좌측 회사 사이드바에서 특정 현장을 선택한 뒤, 상단 탭에서 **`대시보드`** 탭을 선택합니다.
  - URL 예시: `/company/{siteId}/dashboard`
- **확인 포인트**
  - 상단 헤더의 현장명/주소가 백엔드 대시보드 API 응답과 일치하는지 확인.
  - `현장 개요` 카드에서 발주처/공사기간/진행률이 API 응답(`siteInfo`) 기준으로 표시되는지 확인.
  - `인원 현황` 카드에서 총 근로자 수, 상용직/일용직 수, 금일 출근 인원이 `workforceStatus` 값과 일치하는지 확인.
  - `노무 현황 (KPI)` 카드에서 미결 전자계약 건수 및 목록이 `laborStatus.pendingContracts`와 일치하는지 확인.
  - `안전 현황 (KPI)` 카드에서 안전율/안전 경고/교육 미이수/안전 점검 완료 값이 `safetyStatus`와 일치하는지 확인.
  - 대시보드 API가 에러를 반환하는 경우, 우측 상단에 한 번만 에러 토스트가 뜨는지 확인.

## ✅ 테스트

- [x] 정상적인 `siteId`로 대시보드 접속 시 API 응답 데이터가 각 카드에 올바르게 매핑되는지 확인
- [x] 대시보드 API가 500/404 등 에러를 반환할 때 에러 토스트가 노출되는지, 동일 메시지가 반복 노출되지 않는지 확인
- [x] `siteId`가 변경될 때 `useSiteDashboard`의 캐시 키가 달라져 새로운 현장 데이터가 정상적으로 로딩되는지 확인
- [x] 브라우저 탭 전환/재포커스 시 대시보드가 불필요하게 재호출되지 않는지(`refetchOnWindowFocus: false`) 확인
- [x] 대시보드 응답의 특정 필드가 누락/`null`일 때도 UI가 깨지지 않고 기본값(`"-"`, `0`)으로 안전하게 표시되는지 확인

## 🔗 관련 이슈

- Jira: resolves BU-191
- resolves #59 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 대시보드가 이제 실시간 데이터를 표시합니다. 사이트 정보, 인력 현황, 안전 지표 및 계약 상태가 동적으로 로드됩니다.

* **개선사항**
  * 데이터 로딩 중 발생하는 오류에 대한 알림 시스템이 추가되었습니다.
  * 카드 컴포넌트들이 하드코딩된 값 대신 실제 데이터를 표시하도록 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->