### PR TITLE
[BU-199, #72] feat: 기업 현장추가 구현

### DIFF
--- a/src/app/(company)/company/[siteId]/layout.tsx
+++ b/src/app/(company)/company/[siteId]/layout.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 
 import { SidebarLayout } from "@/components/common/SidebarNavigation/sidebar-layout";
 import type { SidebarMenuItem } from "@/components/common/SidebarNavigation/sidebar-navigation";
+import {
+  SiteCreateModal,
+  type SiteFormValues,
+} from "@/components/features/company/site/site-create-modal";
+import { SiteSecretKeyModal } from "@/components/features/company/site/site-secret-key-modal";
 import { useCompanySites } from "@/hooks/use-company-sites";
 
 const BuildingIcon = ({ className }: { className?: string }) => (
@@ -38,12 +43,23 @@ type Props = {
   };
 };
 
+type SiteSecretKeyInfo = {
+  managerKey: string;
+  workerKey: string;
+  createdAt?: string;
+  createdBy?: string;
+};
+
 export default function CompanySiteLayout({ children, params }: Props) {
   const router = useRouter();
   const pathname = usePathname();
   const { data, isLoading, refetch } = useCompanySites();
   const sites = useMemo(() => data?.sites ?? [], [data]);
   const currentSiteId = params.siteId;
+
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isSecretKeyModalOpen, setIsSecretKeyModalOpen] = useState(false);
+  const [secretKeyInfo, setSecretKeyInfo] = useState<SiteSecretKeyInfo | null>(null);
 
   const pathSegments = pathname?.split("/").filter(Boolean) ?? [];
   const currentSection = pathSegments[2] ?? "dashboard";
@@ -83,17 +99,80 @@ export default function CompanySiteLayout({ children, params }: Props) {
     });
   }, [sites, currentSection, currentSiteId, isLoading]);
 
+  const handleOpenCreateModal = () => {
+    setIsCreateModalOpen(true);
+  };
+
+  const handleCloseCreateModal = () => {
+    setIsCreateModalOpen(false);
+  };
+
+  const handleSubmitCreateSite = async (values: SiteFormValues) => {
+    // TODO: 실제 현장 생성 API 연동 시 values를 활용하여 요청 바디 구성
+    void values;
+    const now = new Date();
+    const formattedDate = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, "0")}.${String(
+      now.getDate(),
+    ).padStart(2, "0")}`;
+
+    setSecretKeyInfo({
+      managerKey: "BUILDP-2039-XYZ-9205",
+      workerKey: "BUILDP-2039-XYZ-2057",
+      createdAt: formattedDate,
+      // TODO: 세션 정보에서 실제 로그인한 사용자 이메일 읽어오기
+      createdBy: "관리자 계정 (admin@build-up.kr)",
+    });
+
+    setIsCreateModalOpen(false);
+    setIsSecretKeyModalOpen(true);
+    refetch();
+  };
+
+  const handleCloseSecretKeyModal = () => {
+    setIsSecretKeyModalOpen(false);
+  };
+
+  const handleGoToMain = () => {
+    setIsSecretKeyModalOpen(false);
+    if (currentSiteId) {
+      router.push(`/company/${currentSiteId}/dashboard`);
+    }
+  };
+
+  const handleGoToSiteList = () => {
+    setIsSecretKeyModalOpen(false);
+  };
+
   return (
-    <SidebarLayout
-      menuItems={menuItems}
-      bottomAction={{
-        label: "현장 추가",
-        onClick: () => refetch(),
-      }}
-      searchPlaceholder="현장명 또는 담당자를 검색하세요"
-      logoHref={`/company/${currentSiteId ?? ""}/dashboard`}
-    >
-      {children}
-    </SidebarLayout>
+    <>
+      <SidebarLayout
+        menuItems={menuItems}
+        bottomAction={{
+          label: "현장 추가",
+          onClick: handleOpenCreateModal,
+        }}
+        searchPlaceholder="현장명 또는 담당자를 검색하세요"
+        logoHref={`/company/${currentSiteId ?? ""}/dashboard`}
+      >
+        {children}
+      </SidebarLayout>
+
+      <SiteCreateModal
+        open={isCreateModalOpen}
+        onCancel={handleCloseCreateModal}
+        onSubmit={handleSubmitCreateSite}
+      />
+
+      <SiteSecretKeyModal
+        open={isSecretKeyModalOpen}
+        onClose={handleCloseSecretKeyModal}
+        managerKey={secretKeyInfo?.managerKey ?? ""}
+        workerKey={secretKeyInfo?.workerKey ?? ""}
+        createdAt={secretKeyInfo?.createdAt}
+        createdBy={secretKeyInfo?.createdBy}
+        onGoToMain={handleGoToMain}
+        onGoToSiteList={handleGoToSiteList}
+      />
+    </>
   );
 }

--- a/src/app/(company)/company/[siteId]/layout.tsx
+++ b/src/app/(company)/company/[siteId]/layout.tsx
@@ -12,6 +12,9 @@ import {
 } from "@/components/features/company/site/site-create-modal";
 import { SiteSecretKeyModal } from "@/components/features/company/site/site-secret-key-modal";
 import { useCompanySites } from "@/hooks/use-company-sites";
+import { useCreateSite } from "@/hooks/use-create-site";
+import { useSessionStore } from "@/stores/session-store";
+import { formatTodayAsYyyyMmDdDot } from "@/utils/date";
 
 const BuildingIcon = ({ className }: { className?: string }) => (
   <svg
@@ -54,6 +57,8 @@ export default function CompanySiteLayout({ children, params }: Props) {
   const router = useRouter();
   const pathname = usePathname();
   const { data, isLoading, refetch } = useCompanySites();
+  const createSiteMutation = useCreateSite();
+  const user = useSessionStore((state) => state.user);
   const sites = useMemo(() => data?.sites ?? [], [data]);
   const currentSiteId = params.siteId;
 
@@ -108,19 +113,13 @@ export default function CompanySiteLayout({ children, params }: Props) {
   };
 
   const handleSubmitCreateSite = async (values: SiteFormValues) => {
-    // TODO: 실제 현장 생성 API 연동 시 values를 활용하여 요청 바디 구성
-    void values;
-    const now = new Date();
-    const formattedDate = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, "0")}.${String(
-      now.getDate(),
-    ).padStart(2, "0")}`;
+    const created = await createSiteMutation.mutateAsync(values);
 
     setSecretKeyInfo({
-      managerKey: "BUILDP-2039-XYZ-9205",
-      workerKey: "BUILDP-2039-XYZ-2057",
-      createdAt: formattedDate,
-      // TODO: 세션 정보에서 실제 로그인한 사용자 이메일 읽어오기
-      createdBy: "관리자 계정 (admin@build-up.kr)",
+      managerKey: created.managerSecretKey,
+      workerKey: created.employeeSecretKey,
+      createdAt: formatTodayAsYyyyMmDdDot(),
+      createdBy: user?.name ? `${user.name}` : undefined,
     });
 
     setIsCreateModalOpen(false);

--- a/src/components/features/company/site/site-create-modal.tsx
+++ b/src/components/features/company/site/site-create-modal.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "antd";
+
+import { Button } from "@/components/ui/Button/button";
+import { Input } from "@/components/ui/Input/input";
+
+export type SiteFormValues = {
+  clientName: string;
+  siteName: string;
+  siteAddress: string;
+  startDate: string;
+  endDate: string;
+};
+
+type SiteCreateModalProps = {
+  open: boolean;
+  onCancel: () => void;
+  onSubmit: (values: SiteFormValues) => Promise<void> | void;
+};
+
+type SiteFormErrors = Partial<Record<keyof SiteFormValues, string>>;
+
+export function SiteCreateModal({ open, onCancel, onSubmit }: SiteCreateModalProps) {
+  const [values, setValues] = useState<SiteFormValues>({
+    clientName: "",
+    siteName: "",
+    siteAddress: "",
+    startDate: "",
+    endDate: "",
+  });
+  const [errors, setErrors] = useState<SiteFormErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const resetState = () => {
+    setValues({
+      clientName: "",
+      siteName: "",
+      siteAddress: "",
+      startDate: "",
+      endDate: "",
+    });
+    setErrors({});
+    setSubmitting(false);
+  };
+
+  const handleClose = () => {
+    if (submitting) return;
+    resetState();
+    onCancel();
+  };
+
+  const handleChange = <K extends keyof SiteFormValues>(key: K, value: SiteFormValues[K]) => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+    setErrors((prev) => ({ ...prev, [key]: undefined }));
+  };
+
+  const validate = (): SiteFormErrors => {
+    const nextErrors: SiteFormErrors = {};
+
+    if (!values.clientName.trim()) {
+      nextErrors.clientName = "발주처를 입력해주세요.";
+    }
+    if (!values.siteName.trim()) {
+      nextErrors.siteName = "현장명을 입력해주세요.";
+    }
+    if (!values.siteAddress.trim()) {
+      nextErrors.siteAddress = "현장주소를 입력해주세요.";
+    }
+    if (!values.startDate) {
+      nextErrors.startDate = "시작일을 선택해주세요.";
+    }
+    if (!values.endDate) {
+      nextErrors.endDate = "종료일을 선택해주세요.";
+    }
+
+    if (values.startDate && values.endDate) {
+      const start = new Date(values.startDate);
+      const end = new Date(values.endDate);
+      if (start > end) {
+        nextErrors.endDate = "종료일은 시작일 이후여야 합니다.";
+      }
+    }
+
+    return nextErrors;
+  };
+
+  const handleSubmit = async () => {
+    if (submitting) return;
+
+    const validationErrors = validate();
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      await Promise.resolve(onSubmit(values));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onCancel={handleClose}
+      footer={null}
+      centered
+      width={640}
+      classNames={{
+        content: "bg-white",
+        body: "p-0",
+      }}
+      styles={{
+        content: {
+          backgroundColor: "#ffffff",
+        },
+      }}
+    >
+      <div className="flex flex-col rounded-2xl">
+        <div className="border-b border-border px-8 py-6">
+          <p className="mb-0! text-2xl font-semibold text-brand-primary-strong">현장 등록</p>
+          <p className="mb-0! text-sm text-text-subtle">
+            새로운 현장 정보를 입력하고 Build-Up 시스템에 등록하세요.
+          </p>
+        </div>
+
+        <div className="max-h-[520px] overflow-y-auto px-8 py-6 space-y-5">
+          <Input
+            label="발주처"
+            placeholder="예: 현대건설"
+            value={values.clientName}
+            onChange={(e) => handleChange("clientName", e.target.value)}
+            error={errors.clientName}
+          />
+          <Input
+            label="현장명"
+            placeholder="예: 이천 A 아파트 현장"
+            value={values.siteName}
+            onChange={(e) => handleChange("siteName", e.target.value)}
+            error={errors.siteName}
+          />
+          <Input
+            label="현장주소"
+            placeholder="예: 경기도 이천시 쌀구 하이니스동 21-1"
+            value={values.siteAddress}
+            onChange={(e) => handleChange("siteAddress", e.target.value)}
+            error={errors.siteAddress}
+          />
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <Input
+              label="시작일"
+              type="date"
+              value={values.startDate}
+              onChange={(e) => handleChange("startDate", e.target.value)}
+              error={errors.startDate}
+            />
+            <Input
+              label="종료일"
+              type="date"
+              value={values.endDate}
+              onChange={(e) => handleChange("endDate", e.target.value)}
+              error={errors.endDate}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 border-t border-border px-8 py-4">
+          <Button variant="ghost" size="md" onClick={handleClose} disabled={submitting}>
+            취소
+          </Button>
+          <Button variant="primary" size="md" onClick={handleSubmit} isLoading={submitting}>
+            등록하기
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/features/company/site/site-create-modal.tsx
+++ b/src/components/features/company/site/site-create-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Modal } from "antd";
+import { Modal, notification } from "antd";
 
 import { Button } from "@/components/ui/Button/button";
 import { Input } from "@/components/ui/Input/input";
@@ -104,6 +104,15 @@ export function SiteCreateModal({ open, onCancel, onSubmit }: SiteCreateModalPro
     try {
       setSubmitting(true);
       await Promise.resolve(onSubmit(values));
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "현장 등록 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+      notification.error({
+        message: "현장 등록 실패",
+        description: message,
+      });
     } finally {
       setSubmitting(false);
     }

--- a/src/components/features/company/site/site-create-modal.tsx
+++ b/src/components/features/company/site/site-create-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Modal } from "antd";
 
 import { Button } from "@/components/ui/Button/button";
@@ -32,6 +32,12 @@ export function SiteCreateModal({ open, onCancel, onSubmit }: SiteCreateModalPro
   });
   const [errors, setErrors] = useState<SiteFormErrors>({});
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      resetState();
+    }
+  }, [open]);
 
   const resetState = () => {
     setValues({

--- a/src/components/features/company/site/site-secret-key-modal.tsx
+++ b/src/components/features/company/site/site-secret-key-modal.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "antd";
+
+import { Button } from "@/components/ui/Button/button";
+
+type SiteSecretKeyModalProps = {
+  open: boolean;
+  onClose: () => void;
+  managerKey: string;
+  workerKey: string;
+  createdAt?: string;
+  createdBy?: string;
+  onGoToMain?: () => void;
+  onGoToSiteList?: () => void;
+};
+
+export function SiteSecretKeyModal({
+  open,
+  onClose,
+  managerKey,
+  workerKey,
+  createdAt,
+  createdBy,
+  onGoToMain,
+  onGoToSiteList,
+}: SiteSecretKeyModalProps) {
+  const [copiedTarget, setCopiedTarget] = useState<"manager" | "worker" | null>(null);
+
+  const handleCopy = async (value: string, target: "manager" | "worker") => {
+    if (!value) return;
+
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopiedTarget(target);
+      setTimeout(() => setCopiedTarget((prev) => (prev === target ? null : prev)), 2000);
+    } catch {
+      // clipboard가 동작하지 않는 환경에서는 조용히 실패
+    }
+  };
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleGoToMain = () => {
+    onGoToMain?.();
+  };
+
+  const handleGoToSiteList = () => {
+    onGoToSiteList?.();
+  };
+
+  const renderKeyBlock = (label: string, value: string, target: "manager" | "worker") => {
+    const isCopied = copiedTarget === target;
+
+    return (
+      <div className="space-y-2">
+        <p className="mb-0 text-sm font-medium text-text-strong">{label}</p>
+        <div className="flex items-center justify-between gap-2 rounded-2xl border border-border bg-bg-subtle px-4 py-3">
+          <span className="truncate text-base font-mono tracking-[0.12em] text-brand-primary-strong">
+            {value || "-"}
+          </span>
+          <button
+            type="button"
+            onClick={() => handleCopy(value, target)}
+            className="inline-flex h-8 items-center rounded-lg border border-border bg-white px-3 text-xs font-medium text-text-subtle hover:border-brand-primary hover:text-brand-primary"
+          >
+            {isCopied ? "복사됨" : "복사"}
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Modal
+      open={open}
+      onCancel={handleClose}
+      footer={null}
+      centered
+      width={620}
+      classNames={{
+        content: "bg-white",
+        body: "p-0",
+      }}
+      styles={{
+        content: {
+          backgroundColor: "#ffffff",
+        },
+      }}
+    >
+      <div className="flex flex-col rounded-2xl">
+        {/* Header */}
+        <div className="flex flex-col items-center gap-4 px-8 pt-8">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-[#eff6ff]">
+            <span className="text-3xl text-brand-primary-strong">✓</span>
+          </div>
+          <div className="text-center">
+            <p className="text-2xl font-semibold text-brand-primary-strong">
+              현장 등록이 완료되었습니다!
+            </p>
+            <p className="mb-0 text-sm text-text-subtle">
+              새로운 현장이 성공적으로 등록되었습니다.
+              <br />
+              아래의 시크릿 키를 안전하게 보관해주세요.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4 px-8 py-6">
+          {renderKeyBlock("현장 관리자용 시크릿 키 (Secret Key)", managerKey, "manager")}
+          {renderKeyBlock("근로자용 시크릿 키 (Secret Key)", workerKey, "worker")}
+
+          <div className="mt-2 rounded-lg border border-[#fee2e2] bg-[#fef2f2] px-4 py-3">
+            <p className="mb-0! text-xs leading-relaxed text-[#b91c1c]">
+              이 시크릿 키는 이후 재발급되지 않습니다. 안전한 장소에 복사 또는 저장해 주세요.
+              <br />
+              이후 시크릿 키를 현장 관리자와 근로자에게 전달하세요!
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 border-t border-border px-8 py-4">
+          <Button variant="ghost" size="md" onClick={handleGoToMain}>
+            메인으로 돌아가기
+          </Button>
+          <Button variant="primary" size="md" onClick={handleGoToSiteList}>
+            현장 목록 보기
+          </Button>
+        </div>
+
+        {(createdAt || createdBy) && (
+          <div className="border-t border-border px-8 py-4 text-center text-xs text-text-subtle">
+            {createdAt && <p className="mb-1">등록일: {createdAt}</p>}
+            {createdBy && <p className="mb-0">등록자: {createdBy}</p>}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/hooks/use-create-site.ts
+++ b/src/hooks/use-create-site.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { SiteFormValues } from "@/components/features/company/site/site-create-modal";
+import { createSite } from "@/lib/api/create-site";
+
+export function useCreateSite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["company-sites", "create"],
+    mutationFn: (values: SiteFormValues) => createSite(values),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["company-sites"] });
+    },
+  });
+}

--- a/src/lib/api/create-site.ts
+++ b/src/lib/api/create-site.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import type { SiteFormValues } from "@/components/features/company/site/site-create-modal";
+
+type CreateSitePayload = {
+  siteName: string;
+  siteAddress: string;
+  clientName: string;
+  startDate: string;
+  endDate: string;
+};
+
+type CreateSiteApiResponse = {
+  success: boolean;
+  message: string;
+  code: string;
+  data: {
+    siteId: number;
+    siteName: string;
+    siteAddress: string;
+    clientName: string;
+    startDate: string;
+    endDate: string;
+    managerSecretKey: string;
+    employeeSecretKey: string;
+  };
+};
+
+const FALLBACK_ERROR = "현장 등록 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+
+export type CreatedSiteInfo = CreateSiteApiResponse["data"];
+
+export async function createSite(values: SiteFormValues): Promise<CreatedSiteInfo> {
+  const payload: CreateSitePayload = {
+    siteName: values.siteName,
+    siteAddress: values.siteAddress,
+    clientName: values.clientName,
+    startDate: values.startDate,
+    endDate: values.endDate,
+  };
+
+  let response: Response;
+  try {
+    response = await fetch("/api/v1/sites", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    throw new Error(FALLBACK_ERROR);
+  }
+
+  let json: CreateSiteApiResponse | null = null;
+  try {
+    json = (await response.json()) as CreateSiteApiResponse;
+  } catch {
+    json = null;
+  }
+
+  if (!response.ok) {
+    throw new Error(json?.message || FALLBACK_ERROR);
+  }
+
+  if (!json?.success || !json.data) {
+    throw new Error(json?.message || FALLBACK_ERROR);
+  }
+
+  return json.data;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,10 @@
+"use client";
+
+export function formatTodayAsYyyyMmDdDot() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+
+  return `${year}.${month}.${day}`;
+}


### PR DESCRIPTION
## 🎯 변경 사항

- **현장 추가 모달 UI 구현**
  - Figma 시안(`현장 등록`, `현장 추가_시크릿 키 발급`) 기반으로 현장 등록/시크릿 키 발급 플로우를 컴포넌트로 분리 구현
  - `SiteCreateModal` 추가
    - 필드: 발주처, 현장명, 현장주소, 시작일, 종료일
    - 기본 필수값/기간 유효성 검증(시작일 ≤ 종료일) 적용
  - `SiteSecretKeyModal` 추가
    - 관리자용 시크릿 키 / 근로자용 시크릿 키 표시 및 복사 버튼 제공
    - 경고 안내 문구, 등록일/등록자 정보 영역 구성

- **현장 등록 API 연동 (`POST /v1/sites`)**
  - `createSite` API 함수 추가 (`lib/api/create-site.ts`)
    - 요청: `siteName`, `siteAddress`, `clientName`, `startDate`, `endDate`
    - 응답에서 `managerSecretKey`, `employeeSecretKey` 등 `CreatedSiteInfo` 타입으로 반환
  - `useCreateSite` mutation 훅 추가 (`hooks/use-create-site.ts`)
    - 성공 시 `["company-sites"]` 쿼리 `invalidate`로 현장 목록 자동 갱신

- **레이아웃 및 상태 연동**
  - `company/[siteId]/layout.tsx`
    - 사이드바 `bottomAction`의 `현장 추가` 버튼 클릭 시 `SiteCreateModal` 오픈
    - `handleSubmitCreateSite`에서 `useCreateSite`를 통해 API 호출 후:
      - 응답의 `managerSecretKey`, `employeeSecretKey`를 시크릿 키 모달에 전달
      - 오늘 날짜를 `등록일`로 표시 (유틸 함수 사용)
      - 세션 스토어의 `user.name`을 `등록자`로 표시
    - 현장 생성 후:
      - 현장 등록 모달 닫기 → 시크릿 키 모달 노출 → 현장 목록 refetch

- **유틸 추가**
  - `formatTodayAsYyyyMmDdDot` 유틸 함수 추가 (`utils/date.ts`)
    - 오늘 날짜를 `YYYY.MM.DD` 포맷으로 반환하여 등록일 표시에 사용

---

## 📝 사용 방법

- 회사 대시보드에서 **사이드바 하단 `현장 추가` 버튼 클릭**
  - `현장 등록` 모달이 중앙에 오픈
  - 발주처/현장명/주소/공사 기간(시작일/종료일)을 입력 후 `등록하기` 버튼 클릭
- 등록 성공 시:
  - `현장 등록이 완료되었습니다!` 시크릿 키 모달 표시
  - 관리자/근로자용 시크릿 키를 복사 버튼으로 복사 가능
  - 하단에 `등록일: 오늘 날짜`, `등록자: 세션의 userName` 노출
  - `메인으로 돌아가기` / `현장 목록 보기` 버튼으로 네비게이션

---

## ✅ 테스트

- [x] 사이드바 `현장 추가` 버튼 클릭 시 `현장 등록` 모달이 정상적으로 표시되는지 확인
- [x] 발주처/현장명/현장주소/시작일/종료일 미입력 시 유효성 검증이 동작하는지 확인
- [x] 시작일이 종료일보다 이후일 때 에러 메시지 노출 여부 확인
- [x] 유효한 값 입력 후 `등록하기` 클릭 시 `/api/v1/sites`로 POST 요청이 정상 전송되는지 확인
- [x] API 응답의 `managerSecretKey`, `employeeSecretKey`가 시크릿 키 모달에 올바르게 표시되는지 확인
- [x] 시크릿 키 복사 버튼 클릭 시 클립보드에 값이 복사되고 “복사됨” 상태가 잠시 표시되는지 확인
- [x] 시크릿 키 모달의 등록일이 **오늘 날짜(YYYY.MM.DD)** 로 표시되는지 확인
- [x] 등록자가 세션의 `userName`과 일치하는지 확인
- [x] 현장 생성 후 사이드바 현장 목록이 갱신되는지 확인

---

## 🔗 관련 이슈

- Jira: resolves BU-199
- resolves #72 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사이트 생성 모달 추가: 클라이언트명, 현장명, 주소, 시작/종료 날짜 입력 및 유효성 검사
  * 생성 완료 시 매니저/워커 시크릿 키 표시 모달 추가 및 클립보드 복사·성공 피드백 제공
  * 사이드바 하단에서 사이트 생성 흐름으로 바로 진입 가능
  * 생성 후 생성자/생성일 정보 표시 및 메인/현장 목록으로 이동하는 바로가기 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->