### PR TITLE
[BU-201, #76] feat: 현장 관리자용 근태관리 대시보드 구현

### DIFF
--- a/src/app/(company)/company/[siteId]/attendance/page.tsx
+++ b/src/app/(company)/company/[siteId]/attendance/page.tsx
@@ -57,15 +57,20 @@ export default function CompanyAttendancePage({ params }: Props) {
     isError,
     error,
     refetch,
-  } = useAttendanceRecords({
-    siteId: Number(params.siteId),
-    year: selectedDate.year,
-    month: selectedDate.month,
-    day: selectedDate.day,
-    employmentType,
-    page,
-    size: pageSize,
-  });
+  } = useAttendanceRecords(
+    {
+      siteId: Number(params.siteId),
+      year: selectedDate.year,
+      month: selectedDate.month,
+      day: selectedDate.day,
+      employmentType,
+      page,
+      size: pageSize,
+    },
+    {
+      enabled: true,
+    },
+  );
 
   const records = useMemo(() => attendanceData?.records ?? [], [attendanceData]);
   const summary = attendanceData?.summary;

--- a/src/app/(manager)/manager/attendance/page.tsx
+++ b/src/app/(manager)/manager/attendance/page.tsx
@@ -1,11 +1,206 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { notification } from "antd";
+
+import {
+  InlineDateFilters,
+  type InlineDateValue,
+} from "@/components/common/filters/inline-date-filters";
+import {
+  SegmentedToggle,
+  type SegmentedToggleOption,
+} from "@/components/common/toggles/segmented-toggle";
+import { AttendanceSummarySection } from "@/components/features/company/attendance/attendance-summary-section";
+import { AttendanceTable } from "@/components/features/company/attendance/attendance-table";
+import { useAttendanceRecords } from "@/hooks/use-attendance-records";
+import { useSiteDetail } from "@/hooks/use-site-detail";
+import { useSessionStore } from "@/stores/session-store";
+
+const employmentOptions: SegmentedToggleOption[] = [
+  { label: "상용직 근로자", value: "REGULAR" },
+  { label: "일용직 근로자", value: "DAILY" },
+];
+
 export default function ManagerAttendancePage() {
+  const user = useSessionStore((state) => state.user);
+  const parsedSiteId = user?.siteId ?? 0;
+  const hasValidSiteId = !!parsedSiteId && !Number.isNaN(parsedSiteId);
+
+  const { data: siteDetail } = useSiteDetail(parsedSiteId);
+
+  const [employmentType, setEmploymentType] = useState<"REGULAR" | "DAILY">("REGULAR");
+  const today = useMemo(() => new Date(), []);
+  const [selectedDate, setSelectedDate] = useState<InlineDateValue>({
+    year: String(today.getFullYear()),
+    month: String(today.getMonth() + 1).padStart(2, "0"),
+    day: String(today.getDate()).padStart(2, "0"),
+  });
+
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+
+  const {
+    data: attendanceData,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useAttendanceRecords(
+    {
+      siteId: parsedSiteId,
+      year: selectedDate.year,
+      month: selectedDate.month,
+      day: selectedDate.day,
+      employmentType,
+      page,
+      size: pageSize,
+    },
+    {
+      enabled: hasValidSiteId,
+    },
+  );
+
+  const records = useMemo(() => attendanceData?.records ?? [], [attendanceData]);
+  const summary = attendanceData?.summary;
+  const pagination = attendanceData?.pagination;
+  const totalRecords = pagination?.totalRecords ?? 0;
+  const normalAttendanceCount = summary?.normalAttendance ?? 0;
+  const tableLoading = isLoading || isFetching;
+
+  const lastErrorMessageRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isError || !error) {
+      lastErrorMessageRef.current = null;
+      return;
+    }
+    const message =
+      error instanceof Error ? error.message : "근태 데이터를 불러오는 중 오류가 발생했습니다.";
+    if (lastErrorMessageRef.current === message) return;
+    lastErrorMessageRef.current = message;
+    notification.error({
+      message,
+      placement: "topRight",
+      duration: 3,
+    });
+  }, [isError, error]);
+
+  const yearOptions = useMemo(() => {
+    return Array.from({ length: 3 }).map((_, index) => {
+      const year = String(today.getFullYear() - 1 + index);
+      return { label: `${year}년`, value: year };
+    });
+  }, [today]);
+
+  const monthOptions = useMemo(() => {
+    return Array.from({ length: 12 }).map((_, index) => {
+      const month = String(index + 1).padStart(2, "0");
+      return { label: `${Number(month)}월`, value: month };
+    });
+  }, []);
+
+  const dayOptions = useMemo(() => {
+    return Array.from({ length: 31 }).map((_, index) => {
+      const day = String(index + 1).padStart(2, "0");
+      return { label: `${Number(day)}일`, value: day };
+    });
+  }, []);
+
+  const disabledMessage = !hasValidSiteId
+    ? "현장 정보가 없어 근태 데이터를 불러올 수 없습니다. 관리자에게 현장 정보 설정을 요청해주세요."
+    : undefined;
+
   return (
-    <div className="flex h-[60vh] flex-col items-center justify-center gap-3 text-center">
-      <p className="text-sm font-medium text-brand-primary-strong">근태 관리</p>
-      <p className="max-w-md text-sm text-text-subtle">
-        현장 관리자용 근태 관리 페이지입니다. 이후 Figma 시안에 맞춰 상세 UI와 기능이 추가될
-        예정입니다.
-      </p>
+    <div className="flex flex-col gap-6">
+      <section className="rounded-lg border border-border bg-bg-surface p-3 dark:border-dark-border dark:bg-dark-bg-surface">
+        <header className="space-y-1">
+          <h1 className="mb-0! text-2xl !font-semibold text-text-strong dark:text-dark-text-strong">
+            {siteDetail?.siteName ?? "현장 이름을 불러오는 중..."}
+          </h1>
+          <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
+            {siteDetail?.siteAddress ?? "현장 주소를 불러오는 중입니다."}
+          </p>
+        </header>
+      </section>
+
+      <header className="ml-3 space-y-1">
+        <h2 className="mb-0! text-2xl !font-semibold text-brand-primary-strong dark:text-dark-text-strong">
+          근태 관리
+        </h2>
+        <p className="mb-0! text-sm text-text-subtle dark:text-dark-text-base">
+          관리 중인 현장의 근태 현황을 한눈에 확인하세요.
+        </p>
+      </header>
+
+      <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap gap-3">
+            <InlineDateFilters
+              value={selectedDate}
+              yearOptions={yearOptions}
+              monthOptions={monthOptions}
+              dayOptions={dayOptions}
+              onChange={(newDate) => {
+                setSelectedDate(newDate);
+                setPage(1);
+              }}
+            />
+
+            <SegmentedToggle
+              value={employmentType}
+              onChange={(val) => {
+                setEmploymentType(val as "REGULAR" | "DAILY");
+                setPage(1);
+              }}
+              options={employmentOptions}
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <p className="mb-0! text-sm text-text-subtle dark:text-dark-text-base">
+              {!hasValidSiteId
+                ? "현장 정보 없음"
+                : tableLoading
+                  ? "로딩 중..."
+                  : `${normalAttendanceCount}명 / ${totalRecords}명`}
+            </p>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              disabled={!hasValidSiteId}
+              className="flex h-10 w-10 items-center justify-center rounded-xl border border-border text-text-subtle hover:bg-bg-subtle disabled:cursor-not-allowed disabled:opacity-60 dark:border-dark-border dark:text-dark-text-base dark:hover:bg-dark-bg-surface"
+            >
+              ↻
+            </button>
+          </div>
+        </div>
+
+        <AttendanceSummarySection summary={summary} />
+      </section>
+
+      <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
+        {!hasValidSiteId ? (
+          <div className="flex h-40 items-center justify-center text-sm text-text-subtle dark:text-dark-text-base">
+            {disabledMessage}
+          </div>
+        ) : (
+          <AttendanceTable
+            records={records}
+            isLoading={tableLoading}
+            currentPage={page}
+            pageSize={pageSize}
+            total={totalRecords}
+            locale={{
+              emptyText: isError
+                ? "근태 데이터를 불러오는 중 오류가 발생했습니다."
+                : "표시할 근태 데이터가 없습니다.",
+            }}
+            onPageChange={(newPage) => setPage(newPage)}
+          />
+        )}
+      </section>
     </div>
   );
 }

--- a/src/hooks/use-attendance-records.ts
+++ b/src/hooks/use-attendance-records.ts
@@ -5,7 +5,14 @@ import {
   type GetAttendanceRecordsResponse,
 } from "@/lib/api/get-attendance-records";
 
-export function useAttendanceRecords(params: GetAttendanceRecordsParams) {
+type UseAttendanceRecordsOptions = {
+  enabled?: boolean;
+};
+
+export function useAttendanceRecords(
+  params: GetAttendanceRecordsParams,
+  options?: UseAttendanceRecordsOptions,
+) {
   const queryClient = useQueryClient();
   const queryKey = [
     "attendance",
@@ -26,7 +33,7 @@ export function useAttendanceRecords(params: GetAttendanceRecordsParams) {
     queryFn: () => getAttendanceRecords(params),
     staleTime: Infinity,
     gcTime: 1000 * 60 * 30,
-    enabled: !cachedData,
+    enabled: options?.enabled ?? !cachedData,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/src/hooks/use-login.ts
+++ b/src/hooks/use-login.ts
@@ -35,6 +35,7 @@ export function useLoginMutation(options: UseLoginMutationOptions = {}) {
         name: data.userName,
         email: data.userId,
         role: mappedRole,
+        siteId: data.siteId,
       });
     },
   });

--- a/src/hooks/use-refresh-session.ts
+++ b/src/hooks/use-refresh-session.ts
@@ -36,6 +36,7 @@ export function useRefreshSession(enabled = true) {
       name: query.data.userName,
       email: query.data.userId,
       role: mappedRole,
+      siteId: query.data.siteId,
     });
   }, [query.isSuccess, query.data, clearUser, setUser]);
 

--- a/src/hooks/use-site-detail.ts
+++ b/src/hooks/use-site-detail.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getSiteDetail, type SiteDetail } from "@/lib/api/get-site-detail";
+
+export function useSiteDetail(siteId: number) {
+  return useQuery<SiteDetail>({
+    queryKey: ["site", "detail", siteId],
+    queryFn: () => getSiteDetail(siteId),
+    enabled: !!siteId,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+}

--- a/src/lib/api/get-site-detail.ts
+++ b/src/lib/api/get-site-detail.ts
@@ -1,0 +1,52 @@
+"use client";
+
+export type SiteDetail = {
+  siteId: number;
+  siteName: string;
+  siteAddress: string;
+  clientName: string;
+  startDate: string | null;
+  endDate: string | null;
+  managerName: string;
+};
+
+type GetSiteDetailApiResponse = {
+  success: boolean;
+  message: string;
+  code: string | null;
+  data: SiteDetail;
+};
+
+const FALLBACK_ERROR = "현장 정보를 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+
+export async function getSiteDetail(siteId: number): Promise<SiteDetail> {
+  let response: Response;
+  try {
+    response = await fetch(`/api/v1/sites/${siteId}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    });
+  } catch {
+    throw new Error(FALLBACK_ERROR);
+  }
+
+  let json: GetSiteDetailApiResponse | null = null;
+  try {
+    json = (await response.json()) as GetSiteDetailApiResponse;
+  } catch {
+    json = null;
+  }
+
+  if (!response.ok) {
+    throw new Error(json?.message || FALLBACK_ERROR);
+  }
+
+  if (!json?.success || !json.data) {
+    throw new Error(json?.message || FALLBACK_ERROR);
+  }
+
+  return json.data;
+}

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -7,6 +7,7 @@ export type SessionUser = {
   name: string;
   email: string;
   role: "company" | "siteManager";
+  siteId?: number;
 };
 
 type SessionState = {


### PR DESCRIPTION
## 🎯 변경 사항

- **현장관리자용 근태 관리 대시보드 UI 구현**
  - Figma 시안을 기준으로 `/manager/attendance` 페이지 레이아웃 구성
  - 상단에 **현장 정보 카드**(현장명, 주소)를 흰색 배경 카드 형태로 노출
  - 현장 정보 카드 하단에 **"근태 관리" 제목 + 설명 문구**를 별도 헤더로 배치
  - 기업 근태 관리 화면과 일관된 **날짜 필터, 근로자 유형 토글, 요약 카드, 테이블** UX 적용

- **근태 데이터 API 연동**
  - 기존 기업용 훅 `useAttendanceRecords` 를 옵션(`enabled`) 기반으로 확장하여 **매니저/기업 공용 훅**으로 사용
  - 현장관리자 로그인 시 세션에 저장된 `siteId` 를 이용해 해당 현장의 근태 데이터를 조회
  - `/api/v1/{siteId}/attendance/records` 응답을 기반으로 테이블/요약 카드 연동

- **현장 상세 정보 API 연동**
  - `get-site-detail.ts` 추가: `/api/v1/sites/{siteId}` 호출로 현장명, 주소, 발주처, 공사 기간, 관리자명 등을 조회
  - `use-site-detail` 훅 추가: `useQuery(["site","detail",siteId])` 패턴으로 재사용 가능한 현장 상세 조회 훅 구현
  - 근태 페이지 상단 카드에서 `siteDetail.siteName`, `siteDetail.siteAddress` 를 사용해 현장 정보를 표시

- **세션 스토어 확장 및 로그인/리프레시 연동**
  - `SessionUser` 타입에 `siteId?: number` 필드 추가
  - `useLoginMutation` / `useRefreshSession` 에서 로그인 및 토큰 리프레시 응답의 `siteId` 를 세션에 저장
  - 매니저 레이아웃 및 근태 페이지는 쿼리 파라미터 없이 **세션 기반 siteId** 로 동작하도록 정리

- **에러/빈 상태 처리**
  - 근태 데이터 조회 실패 시 antd `notification.error` 를 통해 상단 토스트 에러 노출
  - `siteId` 가 없거나 유효하지 않은 경우:
    - 헤더/카드에는 로딩용 안내 문구 표시
    - 테이블 영역에는 **현장 정보 부재 안내 문구**를 표시하여 사용성이 떨어지지 않도록 처리

---

## 📝 사용 방법

- **접근 경로**
  - 현장 관리자 계정으로 로그인 후, 좌측 사이드바에서 `근태 관리` 메뉴 선택
  - 자동으로 `/manager/attendance` 로 라우팅되며, 로그인 시 세션에 저장된 `siteId` 기준으로 현장/근태 정보 로딩

- **상단 현장 정보 영역**
  - 상단 흰색 카드:
    - **첫 줄**: 현장명 (예: `이천 A 아파트 현장`)
    - **둘째 줄**: 현장 주소 (예: `경기도 이천시 쌀구 하이니스동 21-1`)
  - 카드 바로 아래:
    - 제목: `근태 관리`
    - 설명: `관리 중인 현장의 근태 현황을 한눈에 확인하세요.`

- **필터 및 근태 현황 확인**
  - 날짜 필터: 연/월/일을 선택해 해당 일자의 근태 데이터를 조회
  - 근로자 유형 토글: `상용직 근로자` / `일용직 근로자` 별로 필터링
  - 상단 요약 카드: 정상 출근/지각/조퇴/결근 인원 수를 카드 형태로 확인
  - 하단 테이블:
    - 근로자명, 주민등록번호, 근태 상태(정상/지각/조퇴/결근), 출/퇴근 시간, 총 근로시간, 야간/연장/휴일 근로시간 등을 행 단위로 확인
    - 테이블 하단 페이지네이션으로 페이지 이동 가능

---

## ✅ 테스트

- [x] 현장 관리자 계정으로 로그인 시 `/manager/attendance` 자동 진입 및 세션의 `siteId` 기반 현장 정보 표시 확인
- [x] `/api/v1/sites/{siteId}` 응답을 통한 상단 현장명/주소 표시 확인
- [x] 날짜 필터 변경 시 근태 데이터 재조회 및 테이블/요약 카드 값 변경 확인
- [x] 근로자 유형 토글(상용직/일용직) 변경 시 근태 데이터 필터링 및 테이블 반영 확인
- [x] 근태 데이터 없음(empty)일 때, 테이블에서 안내 문구가 정상 노출되는지 확인
- [x] 서버 오류 또는 네트워크 오류 발생 시 `notification.error` 로 에러 메시지가 노출되는지 확인
- [x] `siteId` 가 세션에 없는 계정 또는 비정상 상태에서 진입 시, 현장 정보/근태 테이블 대신 적절한 안내 문구가 노출되는지 확인
- [x] 다크 모드/라이트 모드에서 상단 카드 및 테이블/요약 카드 스타일이 디자인에 맞게 노출되는지 확인

---

## 🔗 관련 이슈

- Jira: resolves BU-201
- resolves #76 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 매니저 근태 관리 페이지 전면 개선: 사이트 정보 표시, 인라인 날짜 필터링, 근무 형태 선택 기능 추가
  * 근태 요약 정보 및 상세 테이블 조회 기능 구현
  * 페이지 로딩 및 에러 상태에 대한 사용자 알림 메시지 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->