### PR TITLE
[BU-202, #78] feat: 현장 관리자용 근로계약서 대시보드 구현

### DIFF
--- a/src/app/(manager)/manager/contracts/page.tsx
+++ b/src/app/(manager)/manager/contracts/page.tsx
@@ -55,7 +55,7 @@ export default function ManagerContractsPage() {
 
   const records =
     contractsData?.items.map((item) => ({
-      id: item.employeeId,
+      id: item.contractId, // 각 행은 계약서를 나타내므로 contractId를 고유 키로 사용
       contractId: item.contractId,
       name: item.employeeName,
       residentNumber: item.employeeResidentNumber ?? "",

--- a/src/app/(manager)/manager/contracts/page.tsx
+++ b/src/app/(manager)/manager/contracts/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Input, notification } from "antd";
+import { ManagerContractsTable } from "@/components/features/manager/contracts/manager-contracts-table";
+import { SafetyDocumentModal } from "@/components/features/company/safety/safety-document-modal";
+import { useContractPdf } from "@/hooks/use-contract-pdf";
+import { useContracts } from "@/hooks/use-contracts";
+import { useSiteDetail } from "@/hooks/use-site-detail";
+import { useSessionStore } from "@/stores/session-store";
+import {
+  EmploymentTypeFilterChips,
+  type EmploymentFilterValue,
+} from "@/components/features/manager/employment-type-filter-chips";
+
+type ContractEmploymentFilter = EmploymentFilterValue;
+
+export default function ManagerContractsPage() {
+  const user = useSessionStore((state) => state.user);
+  const parsedSiteId = user?.siteId ?? 0;
+  const hasValidSiteId = !!parsedSiteId && !Number.isNaN(parsedSiteId);
+
+  const { data: siteDetail } = useSiteDetail(parsedSiteId);
+
+  const [employmentFilter, setEmploymentFilter] = useState<ContractEmploymentFilter>("ALL");
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [appliedKeyword, setAppliedKeyword] = useState<string | undefined>(undefined);
+  const [page, setPage] = useState(1);
+  const pageSize = 5;
+
+  const {
+    data: contractsData,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useContracts(
+    {
+      siteId: parsedSiteId,
+      empType:
+        employmentFilter === "ALL"
+          ? undefined
+          : employmentFilter === "REGULAR"
+            ? "PERMANENT"
+            : "DAILY",
+      page,
+      size: pageSize,
+      searchKeyword: appliedKeyword,
+    },
+    {
+      enabled: hasValidSiteId,
+    },
+  );
+
+  const records =
+    contractsData?.items.map((item) => ({
+      id: item.employeeId,
+      contractId: item.contractId,
+      name: item.employeeName,
+      residentNumber: item.employeeResidentNumber ?? "",
+      employmentType:
+        item.empType === "PERMANENT"
+          ? ("REGULAR" as const)
+          : item.empType === "DAILY"
+            ? ("DAILY" as const)
+            : ("UNCONTRACTED" as const),
+      contractStatus: item.contractState,
+      joinDate: item.employeeStartDate,
+      endDate: item.employeeEndDate,
+      phone: undefined, // API에 없음
+    })) ?? [];
+  const totalRecords = contractsData?.pagination.totalElements ?? 0;
+  const totalCount = contractsData?.pagination.totalElements ?? 0;
+  const tableLoading = isLoading || isFetching;
+
+  const [selectedContractId, setSelectedContractId] = useState<number | null>(null);
+
+  const lastErrorMessageRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isError && !error) {
+      lastErrorMessageRef.current = null;
+      return;
+    }
+    if (!isError || !error) {
+      return;
+    }
+    const message =
+      error instanceof Error
+        ? error.message
+        : "근로계약서 데이터를 불러오는 중 오류가 발생했습니다.";
+    if (lastErrorMessageRef.current === message) return;
+    lastErrorMessageRef.current = message;
+    notification.error({
+      message,
+      placement: "topRight",
+      duration: 3,
+    });
+  }, [isError, error]);
+
+  const { data: pdfUrl } = useContractPdf(selectedContractId, Boolean(selectedContractId));
+
+  const handleSearchSubmit = (value: string) => {
+    const keyword = value.trim() || undefined;
+    setAppliedKeyword(keyword);
+    setPage(1);
+  };
+
+  const disabledMessage = !hasValidSiteId
+    ? "현장 정보가 없어 근로계약서 데이터를 불러올 수 없습니다. 관리자에게 현장 정보 설정을 요청해주세요."
+    : undefined;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-lg border border-border bg-bg-surface p-3 dark:border-dark-border dark:bg-dark-bg-surface">
+        <header className="space-y-1">
+          <h1 className="mb-0! text-2xl font-semibold! text-text-strong dark:text-dark-text-strong">
+            {siteDetail?.siteName ?? "현장 이름을 불러오는 중..."}
+          </h1>
+          <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
+            {siteDetail?.siteAddress ?? "현장 주소를 불러오는 중입니다."}
+          </p>
+        </header>
+      </section>
+
+      <header className="ml-3 space-y-1">
+        <h2 className="mb-0! text-2xl font-semibold! text-brand-primary-strong dark:text-dark-text-strong">
+          근로계약서 관리
+        </h2>
+        <p className="mb-0! text-sm text-text-subtle dark:text-dark-text-base">
+          앱을 통해 가입한 근로자의 계약서를 관리합니다.
+        </p>
+      </header>
+
+      <section className="rounded-3xl border border-border bg-bg-surface px-6 py-5 dark:border-dark-border dark:bg-dark-bg-surface">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap items-center gap-3">
+            <EmploymentTypeFilterChips
+              value={employmentFilter}
+              onChange={(val) => {
+                setEmploymentFilter(val);
+                setPage(1);
+              }}
+            />
+          </div>
+
+          <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end">
+            <div className="w-full max-w-md mr-4!">
+              <Input.Search
+                className="employee-search-input"
+                placeholder="근로자명 입력"
+                allowClear
+                value={searchKeyword}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setSearchKeyword(value);
+                  if (value === "") {
+                    setAppliedKeyword(undefined);
+                    setPage(1);
+                  }
+                }}
+                onSearch={handleSearchSubmit}
+                enterButton="검색"
+                size="large"
+              />
+            </div>
+            <div className="flex items-center gap-3 text-sm text-text-subtle dark:text-dark-text-base">
+              <button
+                type="button"
+                onClick={() => refetch()}
+                disabled={!hasValidSiteId}
+                className="flex h-10 w-10 items-center justify-center rounded-xl border border-border text-text-subtle hover:bg-bg-subtle disabled:cursor-not-allowed disabled:opacity-60 dark:border-dark-border dark:text-dark-text-base dark:hover:bg-dark-bg-surface"
+              >
+                ↻
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
+        {!hasValidSiteId ? (
+          <div className="flex h-40 items-center justify-center text-sm text-text-subtle dark:text-dark-text-base">
+            {disabledMessage}
+          </div>
+        ) : (
+          <>
+            <div className="mb-4 flex items-center justify-between">
+              <p className="mb-0 text-xl font-semibold text-text-strong">근로계약서 목록</p>
+              <p className="mb-0 text-sm text-text-subtle">총 {totalCount}명</p>
+            </div>
+
+            <ManagerContractsTable
+              records={records}
+              isLoading={tableLoading}
+              currentPage={page}
+              pageSize={pageSize}
+              total={totalRecords}
+              onPageChange={(newPage) => setPage(newPage)}
+              onOpenContract={(contractId) => setSelectedContractId(contractId)}
+            />
+          </>
+        )}
+      </section>
+
+      <SafetyDocumentModal
+        open={Boolean(selectedContractId)}
+        onClose={() => setSelectedContractId(null)}
+        title="근로계약서"
+        subtitle={siteDetail?.siteName}
+        pdfUrl={pdfUrl ?? undefined}
+        zIndex={2000}
+        onDownload={() => {
+          if (pdfUrl) {
+            window.open(pdfUrl, "_blank");
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/features/manager/contracts/manager-contracts-table.tsx
+++ b/src/components/features/manager/contracts/manager-contracts-table.tsx
@@ -1,0 +1,219 @@
+import type { ColumnsType } from "antd/es/table";
+
+import { Table } from "@/components/ui/Table/table";
+import { StatusPill } from "@/components/ui/StatusPill/status-pill";
+import type { ContractItem } from "@/lib/api/get-contracts";
+import { cn } from "@/utils/cn";
+
+type ManagerContractsRow = {
+  id: number;
+  contractId?: number;
+  name: string;
+  residentNumber: string;
+  employmentType: "REGULAR" | "DAILY" | "UNCONTRACTED";
+  contractStatus?: ContractItem["contractState"] | null;
+  joinDate?: string;
+  endDate?: string;
+  phone?: string;
+};
+
+type ManagerContractsTableProps = {
+  records: ManagerContractsRow[];
+  isLoading: boolean;
+  currentPage: number;
+  pageSize: number;
+  total?: number;
+  onPageChange: (page: number) => void;
+  onOpenContract: (contractId: number) => void;
+};
+
+const buttonClass = (enabled: boolean) =>
+  cn(
+    "inline-flex h-9 min-w-[80px] items-center justify-center rounded-xl border px-4 text-xs font-medium transition",
+    enabled
+      ? "border-brand-primary text-brand-primary hover:bg-brand-primary/5"
+      : "cursor-not-allowed border-border text-text-disabled",
+  );
+
+const employmentLabelMap: Record<ManagerContractsRow["employmentType"], string> = {
+  REGULAR: "상용",
+  DAILY: "일용",
+  UNCONTRACTED: "-",
+};
+
+function mapStatusToLabelAndVariant(
+  empType: ManagerContractsRow["employmentType"],
+  contractStatus?: ContractItem["contractState"] | null,
+): { label: string; variant: Parameters<typeof StatusPill>[0]["variant"] } {
+  // emp_type이 UNCONTRACTED면 미작성
+  if (empType === "UNCONTRACTED") {
+    return { label: "미작성", variant: "neutral" };
+  }
+
+  // 그 외는 contract status 기준
+  if (!contractStatus || contractStatus === "DRAFT") {
+    return { label: "미작성", variant: "neutral" };
+  }
+  if (
+    contractStatus === "MANAGER_SIGNING_PENDING" ||
+    contractStatus === "EMPLOYEE_SIGNING_PENDING" ||
+    contractStatus === "SENT" ||
+    contractStatus === "ADMIN_SIGNED"
+  ) {
+    return { label: "서명 대기", variant: "warning" };
+  }
+  if (contractStatus === "FULLY_SIGNED") {
+    return { label: "승인 완료", variant: "success" };
+  }
+  if (contractStatus === "TERMINATED" || contractStatus === "VOID") {
+    return { label: "계약 종료", variant: "danger" };
+  }
+  return { label: contractStatus, variant: "info" };
+}
+
+export function ManagerContractsTable({
+  records,
+  isLoading,
+  currentPage,
+  pageSize,
+  total,
+  onPageChange,
+  onOpenContract,
+}: ManagerContractsTableProps) {
+  const columns: ColumnsType<ManagerContractsRow> = [
+    {
+      title: "구분",
+      dataIndex: "employmentType",
+      key: "employmentType",
+      align: "center",
+      render: (value: ManagerContractsRow["employmentType"]) => employmentLabelMap[value] ?? "-",
+    },
+    {
+      title: "사원명",
+      dataIndex: "name",
+      key: "name",
+      align: "center",
+    },
+    {
+      title: "입사일",
+      dataIndex: "joinDate",
+      key: "joinDate",
+      align: "center",
+      render: (value) => value ?? "-",
+    },
+    {
+      title: "퇴사일",
+      dataIndex: "endDate",
+      key: "endDate",
+      align: "center",
+      render: (value) => value ?? "-",
+    },
+    {
+      title: "주민등록번호",
+      dataIndex: "residentNumber",
+      key: "residentNumber",
+      align: "center",
+      render: (value) => value ?? "-",
+    },
+    {
+      title: "연락처",
+      dataIndex: "phone",
+      key: "phone",
+      align: "center",
+      render: (value) => value ?? "-",
+    },
+    {
+      title: "현황",
+      key: "contractStatus",
+      align: "center",
+      render: (_, record) => {
+        const { label, variant } = mapStatusToLabelAndVariant(
+          record.employmentType,
+          record.contractStatus,
+        );
+        return (
+          <StatusPill size="sm" variant={variant}>
+            {label}
+          </StatusPill>
+        );
+      },
+    },
+    {
+      title: "근로계약서",
+      key: "contractAction",
+      align: "center",
+      render: (_, record) => {
+        const empType = record.employmentType;
+        const contractStatus = record.contractStatus;
+
+        // emp_type이 UNCONTRACTED면 작성 버튼 (contractId가 없을 수 있음)
+        if (empType === "UNCONTRACTED") {
+          return (
+            <button
+              type="button"
+              onClick={() => {
+                // TODO: 작성 기능 구현 필요
+              }}
+              className={buttonClass(true)}
+            >
+              작성
+            </button>
+          );
+        }
+
+        // 그 외는 contract status 기준
+        const isDraft = !contractStatus || contractStatus === "DRAFT";
+        const isSigningPending =
+          contractStatus === "MANAGER_SIGNING_PENDING" ||
+          contractStatus === "EMPLOYEE_SIGNING_PENDING" ||
+          contractStatus === "SENT" ||
+          contractStatus === "ADMIN_SIGNED";
+        const isFullySigned = contractStatus === "FULLY_SIGNED";
+        const isTerminated = contractStatus === "TERMINATED" || contractStatus === "VOID";
+
+        let label = "조회";
+        if (isDraft) label = "작성";
+        else if (isSigningPending) label = "조회";
+        else if (isFullySigned) label = "열람";
+        else if (isTerminated) label = "조회";
+
+        const enabled = !isTerminated && record.contractId != null;
+
+        return (
+          <button
+            type="button"
+            onClick={() => {
+              if (enabled && record.contractId) {
+                onOpenContract(record.contractId);
+              }
+            }}
+            disabled={!enabled}
+            className={buttonClass(enabled)}
+          >
+            {label}
+          </button>
+        );
+      },
+    },
+  ];
+
+  return (
+    <Table<ManagerContractsRow>
+      columns={columns}
+      dataSource={records}
+      rowKey={(record) => record.id}
+      loading={isLoading}
+      pagination={{
+        current: currentPage,
+        pageSize,
+        total,
+        onChange: onPageChange,
+        position: ["bottomCenter"],
+        showSizeChanger: false,
+      }}
+      showHeaderBar={false}
+      borderedContainer={false}
+      className="rounded-2xl border border-border bg-white dark:border-dark-border dark:bg-dark-bg-surface"
+    />
+  );
+}

--- a/src/components/features/manager/employment-type-filter-chips.tsx
+++ b/src/components/features/manager/employment-type-filter-chips.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { cn } from "@/utils/cn";
+
+export type EmploymentFilterValue = "ALL" | "REGULAR" | "DAILY";
+
+type EmploymentTypeFilterChipsProps = {
+  value: EmploymentFilterValue;
+  onChange: (value: EmploymentFilterValue) => void;
+  className?: string;
+};
+
+export function EmploymentTypeFilterChips({
+  value,
+  onChange,
+  className,
+}: EmploymentTypeFilterChipsProps) {
+  const options: { label: string; value: EmploymentFilterValue }[] = [
+    { label: "전체", value: "ALL" },
+    { label: "상용", value: "REGULAR" },
+    { label: "일용", value: "DAILY" },
+  ];
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full bg-bg-subtle px-2 py-1 text-sm dark:bg-dark-bg-subtle",
+        className,
+      )}
+    >
+      <div className="flex gap-1">
+        {options.map((option) => {
+          const active = value === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onChange(option.value)}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium transition",
+                active
+                  ? "bg-brand-primary-strong text-white! shadow-sm"
+                  : "bg-transparent text-text-subtle hover:bg-bg-surface/70 dark:text-dark-text-base dark:hover:bg-dark-bg-surface/70",
+              )}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-contract-pdf.ts
+++ b/src/hooks/use-contract-pdf.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getContractPdfUrl } from "@/lib/api/get-contract-pdf";
+
+export function useContractPdf(contractId: number | null, enabled = true) {
+  return useQuery({
+    queryKey: ["contract", "pdf", contractId],
+    queryFn: () => (contractId != null ? getContractPdfUrl(contractId) : Promise.resolve("")),
+    enabled: enabled && contractId != null,
+    staleTime: 1000 * 60 * 15, // 15분 (URL 만료 시간)
+    gcTime: 1000 * 60 * 15,
+  });
+}

--- a/src/hooks/use-contracts.ts
+++ b/src/hooks/use-contracts.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import {
+  getContracts,
+  type GetContractsParams,
+  type GetContractsResponse,
+} from "@/lib/api/get-contracts";
+
+type UseContractsOptions = {
+  enabled?: boolean;
+};
+
+export function useContracts(params: GetContractsParams, options?: UseContractsOptions) {
+  return useQuery<GetContractsResponse>({
+    queryKey: [
+      "contracts",
+      "list",
+      params.siteId,
+      params.page,
+      params.size,
+      params.empType,
+      params.searchKeyword,
+    ],
+    queryFn: () => getContracts(params),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    placeholderData: keepPreviousData,
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/src/hooks/use-employees.ts
+++ b/src/hooks/use-employees.ts
@@ -5,7 +5,11 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { getEmployeeList } from "@/lib/api/get-employees";
 import type { GetEmployeeListParams, GetEmployeeListResponse } from "@/types/employee";
 
-export function useEmployees(params: GetEmployeeListParams) {
+type UseEmployeesOptions = {
+  enabled?: boolean;
+};
+
+export function useEmployees(params: GetEmployeeListParams, options?: UseEmployeesOptions) {
   return useQuery<GetEmployeeListResponse>({
     queryKey: [
       "employees",
@@ -23,5 +27,6 @@ export function useEmployees(params: GetEmployeeListParams) {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     placeholderData: keepPreviousData,
+    enabled: options?.enabled ?? true,
   });
 }

--- a/src/lib/api/get-contract-pdf.ts
+++ b/src/lib/api/get-contract-pdf.ts
@@ -1,0 +1,30 @@
+export type GetContractPdfApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    url: string;
+    expiresAt: string;
+  };
+};
+
+export async function getContractPdfUrl(contractId: number): Promise<string> {
+  const response = await fetch(`/api/v1/documents/contracts/${contractId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("근로계약서 PDF를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetContractPdfApiResponse;
+
+  if (!json.success || !json.data?.url) {
+    throw new Error(json.message || "근로계약서 PDF URL이 응답에 포함되어 있지 않습니다.");
+  }
+
+  return json.data.url;
+}

--- a/src/lib/api/get-contracts.ts
+++ b/src/lib/api/get-contracts.ts
@@ -1,0 +1,108 @@
+export type ContractState =
+  | "DRAFT"
+  | "MANAGER_SIGNING_PENDING"
+  | "EMPLOYEE_SIGNING_PENDING"
+  | "SENT"
+  | "ADMIN_SIGNED"
+  | "FULLY_SIGNED"
+  | "TERMINATED"
+  | "VOID";
+
+export type EmpType = "PERMANENT" | "DAILY" | "UNCONTRACTED";
+
+export type ContractItem = {
+  contractId: number;
+  employeeId: number;
+  employeeName: string;
+  employeeResidentNumber: string | null;
+  empType: EmpType;
+  role: string;
+  contractState: ContractState;
+  employeeStartDate: string;
+  employeeEndDate: string;
+  writtenAt: string;
+  corporationSignedAt: string | null;
+  employeeSignedAt: string | null;
+};
+
+export type ContractsListApiResponse = {
+  success: boolean;
+  message: string;
+  code: string | null;
+  data: {
+    items: ContractItem[];
+    pageInfo: {
+      currentPage: number;
+      pageSize: number;
+      totalElements: number;
+      totalPages: number;
+      hasNext: boolean;
+      hasPrevious: boolean;
+    };
+  };
+};
+
+export type GetContractsParams = {
+  siteId: number;
+  page?: number;
+  size?: number;
+  empType?: "PERMANENT" | "DAILY";
+  searchKeyword?: string;
+};
+
+export type GetContractsResponse = {
+  items: ContractItem[];
+  pagination: {
+    currentPage: number;
+    pageSize: number;
+    totalElements: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrevious: boolean;
+  };
+};
+
+export async function getContracts(params: GetContractsParams): Promise<GetContractsResponse> {
+  const queryParams = new URLSearchParams({
+    page: String(params.page ?? 1),
+    size: String(params.size ?? 20),
+  });
+
+  if (params.empType) {
+    queryParams.set("empType", params.empType);
+  }
+
+  if (params.searchKeyword) {
+    queryParams.set("name", params.searchKeyword);
+  }
+
+  const response = await fetch(`/api/v1/${params.siteId}/contracts?${queryParams.toString()}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("근로계약서 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as ContractsListApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "근로계약서 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  return {
+    items: json.data.items,
+    pagination: {
+      currentPage: json.data.pageInfo.currentPage,
+      pageSize: json.data.pageInfo.pageSize,
+      totalElements: json.data.pageInfo.totalElements,
+      totalPages: json.data.pageInfo.totalPages,
+      hasNext: json.data.pageInfo.hasNext,
+      hasPrevious: json.data.pageInfo.hasPrevious,
+    },
+  };
+}

--- a/src/lib/api/get-employees.ts
+++ b/src/lib/api/get-employees.ts
@@ -88,8 +88,10 @@ type EmployeePayslipsApiResponse =
       data?: EmployeePayslipsApiPayload;
     };
 
-function mapEmploymentTypeToQuery(type: EmploymentType): "DAILY" | "PERMANENT" {
-  return type === "REGULAR" ? "PERMANENT" : "DAILY";
+function mapEmploymentTypeToQuery(type: EmploymentType): "DAILY" | "PERMANENT" | null {
+  if (type === "REGULAR") return "PERMANENT";
+  if (type === "DAILY") return "DAILY";
+  return null;
 }
 
 function mapEmploymentTypeFromApi(empType: string): EmploymentType {
@@ -108,7 +110,10 @@ export async function getEmployeeList(
   });
 
   if (params.employmentType) {
-    queryParams.set("empType", mapEmploymentTypeToQuery(params.employmentType));
+    const mappedType = mapEmploymentTypeToQuery(params.employmentType);
+    if (mappedType !== null) {
+      queryParams.set("empType", mappedType);
+    }
   }
 
   if (params.searchKeyword) {

--- a/src/lib/api/get-employees.ts
+++ b/src/lib/api/get-employees.ts
@@ -93,17 +93,23 @@ function mapEmploymentTypeToQuery(type: EmploymentType): "DAILY" | "PERMANENT" {
 }
 
 function mapEmploymentTypeFromApi(empType: string): EmploymentType {
-  return empType === "PERMANENT" ? "REGULAR" : "DAILY";
+  if (empType === "PERMANENT") return "REGULAR";
+  if (empType === "DAILY") return "DAILY";
+  if (empType === "UNCONTRACTED") return "UNCONTRACTED";
+  return "DAILY"; // fallback
 }
 
 export async function getEmployeeList(
   params: GetEmployeeListParams,
 ): Promise<GetEmployeeListResponse> {
   const queryParams = new URLSearchParams({
-    empType: mapEmploymentTypeToQuery(params.employmentType),
     page: String(params.page),
     size: String(params.size),
   });
+
+  if (params.employmentType) {
+    queryParams.set("empType", mapEmploymentTypeToQuery(params.employmentType));
+  }
 
   if (params.searchKeyword) {
     queryParams.set("name", params.searchKeyword);

--- a/src/types/employee.ts
+++ b/src/types/employee.ts
@@ -1,4 +1,4 @@
-export type EmploymentType = "REGULAR" | "DAILY";
+export type EmploymentType = "REGULAR" | "DAILY" | "UNCONTRACTED";
 
 export type EmployeeRecord = {
   id: number;
@@ -20,7 +20,16 @@ export type EmployeeDetail = {
   resignDate?: string;
 };
 
-export type EmployeeDocumentStatus = "DRAFT" | "ONGOING" | "COMPLETED" | string;
+export type EmployeeDocumentStatus =
+  | "DRAFT"
+  | "MANAGER_SIGNING_PENDING"
+  | "EMPLOYEE_SIGNING_PENDING"
+  | "SENT"
+  | "ADMIN_SIGNED"
+  | "FULLY_SIGNED"
+  | "TERMINATED"
+  | "VOID"
+  | string;
 
 export type EmployeeContractDocument = {
   id: number;
@@ -38,7 +47,7 @@ export type EmployeePayslipDocument = {
 
 export type GetEmployeeListParams = {
   siteId: number;
-  employmentType: EmploymentType;
+  employmentType?: EmploymentType;
   page: number;
   size: number;
   searchKeyword?: string;


### PR DESCRIPTION
## 🎯 변경 사항

현장 관리자용 근로계약서 관리 대시보드 페이지를 구현하고 API 연동을 완료했습니다.

### 주요 구현 내용

1. **근로계약서 관리 대시보드 페이지**
   - `/manager/contracts` 경로에 현장 관리자용 근로계약서 관리 페이지 구현
   - 현장 정보 표시 (현장명, 주소)
   - 근로계약서 목록 테이블 및 필터링 기능

2. **UI 컴포넌트**
   - `ManagerContractsTable`: 근로계약서 목록을 표시하는 테이블 컴포넌트
     - 구분(상용/일용), 사원명, 입사일, 퇴사일, 주민등록번호, 연락처, 현황, 근로계약서 액션 컬럼
     - 계약 상태에 따른 버튼 표시 (작성/조회/열람)
     - 계약 상태별 StatusPill 표시 (미작성/서명 대기/승인 완료/계약 종료)
   - `EmploymentTypeFilterChips`: 고용 형태 필터 컴포넌트 (전체/상용/일용)
   - 근로계약서 PDF 조회 모달 (`SafetyDocumentModal` 재사용)

3. **API 클라이언트**
   - `getContracts`: 근로계약서 목록 조회 API
     - 페이지네이션 지원
     - 고용 형태 필터링 (PERMANENT/DAILY)
     - 근로자명 검색 기능
   - `getContractPdfUrl`: 근로계약서 PDF URL 조회 API
     - 서명된 계약서 PDF 조회

4. **React Query 훅**
   - `useContracts`: 근로계약서 목록 조회 훅
     - 쿼리 키 분리로 필터/검색/페이지 변경 시 자동 리패치
     - placeholderData로 페이지 전환 시 이전 데이터 유지
   - `useContractPdf`: 근로계약서 PDF 조회 훅
     - 15분 캐싱 (URL 만료 시간 고려)

5. **타입 정의**
   - `ContractState`: 근로계약서 상태 타입 (DRAFT, MANAGER_SIGNING_PENDING, EMPLOYEE_SIGNING_PENDING, SENT, ADMIN_SIGNED, FULLY_SIGNED, TERMINATED, VOID)
   - `EmpType`: 고용 형태 타입 (PERMANENT, DAILY, UNCONTRACTED)
   - `ContractItem`: 근로계약서 항목 타입

### 기능 상세

- **필터링**: 전체/상용/일용 고용 형태 필터
- **검색**: 근로자명으로 검색 (Enter 키 또는 검색 버튼 클릭)
- **페이지네이션**: 5개씩 페이지 단위로 표시
- **계약서 조회**: 계약서 ID를 통해 PDF 모달에서 조회
- **에러 처리**: API 에러 발생 시 notification으로 사용자에게 알림
- **로딩 상태**: 테이블 로딩 상태 표시
- **새로고침**: 수동 새로고침 버튼 제공

## 📝 사용 방법

1. **페이지 접근**
   - 현장 관리자로 로그인 후 사이드바에서 "근로계약서" 메뉴 클릭
   - 또는 `/manager/contracts` 경로로 직접 접근

2. **근로계약서 목록 조회**
   - 페이지 로드 시 자동으로 해당 현장의 근로계약서 목록이 표시됩니다
   - 현장 정보가 없는 경우 안내 메시지가 표시됩니다

3. **필터링**
   - 상단의 "전체/상용/일용" 필터 칩을 클릭하여 고용 형태별로 필터링
   - 필터 변경 시 페이지는 1페이지로 초기화됩니다

4. **검색**
   - 검색 입력창에 근로자명을 입력하고 Enter 키를 누르거나 "검색" 버튼을 클릭
   - 검색어를 지우면 전체 목록이 다시 표시됩니다

5. **계약서 조회**
   - 테이블의 "조회" 또는 "열람" 버튼을 클릭하여 해당 근로계약서 PDF를 모달에서 확인
   - 모달에서 PDF 다운로드 가능

6. **페이지 이동**
   - 테이블 하단의 페이지네이션을 통해 다른 페이지로 이동

7. **데이터 새로고침**
   - 상단 우측의 새로고침 버튼(↻)을 클릭하여 최신 데이터로 갱신

## ✅ 테스트

- [x] 현장 관리자 로그인 후 근로계약서 페이지 접근 가능
- [x] 근로계약서 목록이 정상적으로 표시됨
- [x] 고용 형태 필터(전체/상용/일용) 동작 확인
- [x] 근로자명 검색 기능 동작 확인
- [x] 페이지네이션 동작 확인
- [ ] 계약서 조회 버튼 클릭 시 PDF 모달 표시 확인
- [ ] 계약 상태별 StatusPill 표시 확인 (미작성/서명 대기/승인 완료/계약 종료)
- [ ] 계약 상태별 버튼 텍스트 및 활성화 상태 확인
- [x] API 에러 발생 시 에러 메시지 표시 확인
- [x] 로딩 상태 표시 확인
- [x] 현장 정보가 없는 경우 안내 메시지 표시 확인
- [x] 다크모드에서 UI 정상 표시 확인
- [x] 반응형 레이아웃 동작 확인

## 🔗 관련 이슈

- Jira: resolves BU-202
- resolves #78 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자용 근로계약서 관리 페이지 추가: 사이트 정보, 검색 제출/초기화, 페이징, 수동 새로고침 포함
  * 계약 목록 테이블 추가: 직원 정보, 입/퇴사일, 주민번호(가림), 연락처, 상태 표시 및 문서 열람/다운로드 가능
  * 고용 형태 필터(전체/상용/일용) 컴포넌트 추가
  * 계약 PDF 조회 기능 추가 및 API 오류/로딩 알림 처리 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->