### PR TITLE
[BU-209, #86] feat: 현장 관리자용 안전교육일지 작성 기능 구현

### DIFF
--- a/src/app/(manager)/manager/safety-education/create/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/page.tsx
@@ -40,6 +40,8 @@ export default function ManagerSafetyEducationCreatePage() {
   const [educationLocation, setEducationLocation] = useState("");
 
   const handleCancel = () => {
+    // 세션 스토리지 정리
+    sessionStorage.removeItem("safety-education-form-data");
     router.back();
   };
 
@@ -72,8 +74,8 @@ export default function ManagerSafetyEducationCreatePage() {
       return;
     }
 
-    // 다음 단계로 이동 (교육 정보를 query params로 전달)
-    const params = new URLSearchParams({
+    // 교육 정보를 세션 스토리지에 저장 (긴 텍스트를 URL에 포함하지 않기 위해)
+    const educationData = {
       siteName: basicInfo.siteName,
       siteAddress: basicInfo.siteAddress,
       educationType,
@@ -81,6 +83,13 @@ export default function ManagerSafetyEducationCreatePage() {
       educationContent,
       instructorName,
       educationLocation,
+    };
+    sessionStorage.setItem("safety-education-form-data", JSON.stringify(educationData));
+
+    // 다음 단계로 이동 (짧은 정보만 query params로 전달)
+    const params = new URLSearchParams({
+      educationType,
+      educationSubject,
     });
 
     router.push(`/manager/safety-education/create/select?${params.toString()}`);

--- a/src/app/(manager)/manager/safety-education/create/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import dayjs from "dayjs";
+import { Input, Radio, notification } from "antd";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/Button/button";
+import { useContractInfo } from "@/hooks/use-contract-info";
+import { useSiteDetail } from "@/hooks/use-site-detail";
+import { useSessionStore } from "@/stores/session-store";
+
+type EducationType = "REGULAR" | "HIRING" | "WORK_CHANGE" | "SPECIAL" | "OTHER";
+
+export default function ManagerSafetyEducationCreatePage() {
+  const router = useRouter();
+  const user = useSessionStore((state) => state.user);
+  const parsedSiteId = user?.siteId ?? 0;
+  const hasValidSiteId = !!parsedSiteId && !Number.isNaN(parsedSiteId);
+
+  const { data: siteDetail } = useSiteDetail(parsedSiteId);
+  const { data: contractInfo } = useContractInfo(parsedSiteId, { enabled: hasValidSiteId });
+
+  const today = dayjs().format("YYYY년 MM월 DD일");
+  const authorName = user?.name ? `${user.name} (${user.role ?? ""})` : "";
+
+  const basicInfo = useMemo(
+    () => ({
+      siteName: contractInfo?.siteName ?? siteDetail?.siteName ?? "",
+      siteAddress: contractInfo?.siteAddress ?? siteDetail?.siteAddress ?? "",
+      educationDate: today,
+      author: authorName,
+    }),
+    [contractInfo, siteDetail, today, authorName],
+  );
+
+  const [educationType, setEducationType] = useState<EducationType | undefined>(undefined);
+  const [otherEducationType, setOtherEducationType] = useState("");
+  const [educationSubject, setEducationSubject] = useState("");
+  const [educationContent, setEducationContent] = useState("");
+  const [instructorName, setInstructorName] = useState("");
+  const [educationLocation, setEducationLocation] = useState("");
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  const handleNext = () => {
+    // 유효성 검사
+    if (!educationType) {
+      notification.warning({
+        message: "교육 구분을 선택해주세요.",
+        placement: "topRight",
+        duration: 3,
+      });
+      return;
+    }
+
+    if (educationType === "OTHER" && !otherEducationType.trim()) {
+      notification.warning({
+        message: "기타 교육 구분을 입력해주세요.",
+        placement: "topRight",
+        duration: 3,
+      });
+      return;
+    }
+
+    if (!educationSubject.trim()) {
+      notification.warning({
+        message: "교육과목을 입력해주세요.",
+        placement: "topRight",
+        duration: 3,
+      });
+      return;
+    }
+
+    if (!educationContent.trim()) {
+      notification.warning({
+        message: "교육내용을 입력해주세요.",
+        placement: "topRight",
+        duration: 3,
+      });
+      return;
+    }
+
+    // 다음 단계로 이동 (교육 정보를 query params로 전달)
+    const params = new URLSearchParams({
+      siteName: basicInfo.siteName,
+      siteAddress: basicInfo.siteAddress,
+      educationDate: dayjs().format("YYYY-MM-DD"),
+      author: basicInfo.author,
+      educationType,
+      otherEducationType: educationType === "OTHER" ? otherEducationType : "",
+      educationSubject,
+      educationContent,
+      instructorName,
+      educationLocation,
+    });
+
+    router.push(`/manager/safety-education/create/select?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-lg border border-border bg-bg-surface p-3 dark:border-dark-border dark:bg-dark-bg-surface">
+        <header className="space-y-1">
+          <h1 className="mb-0! text-2xl font-semibold! text-text-strong dark:text-dark-text-strong">
+            {siteDetail?.siteName ?? "현장 이름을 불러오는 중..."}
+          </h1>
+          <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
+            {siteDetail?.siteAddress ?? "현장 주소를 불러오는 중입니다."}
+          </p>
+        </header>
+      </section>
+
+      <header className="ml-3 space-y-1">
+        <h2 className="mb-0! text-2xl font-semibold! text-brand-primary-strong dark:text-dark-text-strong">
+          안전교육일지 작성
+        </h2>
+        <p className="mb-0! text-sm text-text-subtle dark:text-dark-text-base">
+          진행한 안전교육에 대해 일지를 작성합니다.
+        </p>
+      </header>
+
+      {/* 기본 정보 섹션 */}
+      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-5 dark:border-dark-border dark:bg-dark-bg-surface">
+        <h3 className="mb-4 text-lg font-normal text-brand-primary-strong">기본 정보</h3>
+        <div className="grid gap-6 md:grid-cols-2">
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">현장명</label>
+            <Input value={basicInfo.siteName} disabled className="rounded-lg" />
+          </div>
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">현장주소</label>
+            <Input value={basicInfo.siteAddress} disabled className="rounded-lg" />
+          </div>
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">작성일자</label>
+            <Input value={basicInfo.educationDate} disabled className="rounded-lg" />
+          </div>
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">작성자</label>
+            <Input value={basicInfo.author} disabled className="rounded-lg" />
+          </div>
+        </div>
+      </section>
+
+      {/* 교육 정보 섹션 */}
+      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-5 dark:border-dark-border dark:bg-dark-bg-surface">
+        <h3 className="mb-4 text-lg font-normal text-brand-primary-strong">교육 정보</h3>
+        <div className="space-y-6">
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">교육 구분</label>
+            <Radio.Group
+              value={educationType}
+              onChange={(e) => {
+                setEducationType(e.target.value);
+                if (e.target.value !== "OTHER") {
+                  setOtherEducationType("");
+                }
+              }}
+              className="flex flex-wrap gap-4"
+            >
+              <Radio value="REGULAR">정기교육</Radio>
+              <Radio value="HIRING">채용 시 교육</Radio>
+              <Radio value="WORK_CHANGE">작업내용 변경 시 교육</Radio>
+              <Radio value="SPECIAL">특별교육</Radio>
+              <Radio value="OTHER">기타</Radio>
+            </Radio.Group>
+            {educationType === "OTHER" && (
+              <Input
+                value={otherEducationType}
+                onChange={(e) => setOtherEducationType(e.target.value)}
+                placeholder="기타 선택 시 직접 입력"
+                className="mt-3 rounded-lg"
+              />
+            )}
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">교육과목</label>
+            <Input
+              value={educationSubject}
+              onChange={(e) => setEducationSubject(e.target.value)}
+              placeholder="예: 금속 절삭유 사용 시 안전사고 예방"
+              className="rounded-lg"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">교육내용</label>
+            <Input.TextArea
+              value={educationContent}
+              onChange={(e) => setEducationContent(e.target.value)}
+              placeholder="예: 절삭유의 인체 유해성 및 예방조치 안내"
+              rows={6}
+              className="rounded-lg"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">교육 실시자 성명</label>
+            <Input
+              value={instructorName}
+              onChange={(e) => setInstructorName(e.target.value)}
+              placeholder="예: 김나나"
+              className="rounded-lg"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">교육 실시 장소</label>
+            <Input
+              value={educationLocation}
+              onChange={(e) => setEducationLocation(e.target.value)}
+              placeholder="예: 공장 내 회의실"
+              className="rounded-lg"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* 하단 액션 버튼 */}
+      <section className="flex justify-end gap-3">
+        <Button variant="secondary" size="md" onClick={handleCancel}>
+          취소
+        </Button>
+        <Button variant="primary" size="md" onClick={handleNext}>
+          다음 단계로
+        </Button>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(manager)/manager/safety-education/create/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/page.tsx
@@ -34,7 +34,6 @@ export default function ManagerSafetyEducationCreatePage() {
   );
 
   const [educationType, setEducationType] = useState<EducationType | undefined>(undefined);
-  const [otherEducationType, setOtherEducationType] = useState("");
   const [educationSubject, setEducationSubject] = useState("");
   const [educationContent, setEducationContent] = useState("");
   const [instructorName, setInstructorName] = useState("");
@@ -49,15 +48,6 @@ export default function ManagerSafetyEducationCreatePage() {
     if (!educationType) {
       notification.warning({
         message: "교육 구분을 선택해주세요.",
-        placement: "topRight",
-        duration: 3,
-      });
-      return;
-    }
-
-    if (educationType === "OTHER" && !otherEducationType.trim()) {
-      notification.warning({
-        message: "기타 교육 구분을 입력해주세요.",
         placement: "topRight",
         duration: 3,
       });
@@ -86,10 +76,7 @@ export default function ManagerSafetyEducationCreatePage() {
     const params = new URLSearchParams({
       siteName: basicInfo.siteName,
       siteAddress: basicInfo.siteAddress,
-      educationDate: dayjs().format("YYYY-MM-DD"),
-      author: basicInfo.author,
       educationType,
-      otherEducationType: educationType === "OTHER" ? otherEducationType : "",
       educationSubject,
       educationContent,
       instructorName,
@@ -154,9 +141,6 @@ export default function ManagerSafetyEducationCreatePage() {
               value={educationType}
               onChange={(e) => {
                 setEducationType(e.target.value);
-                if (e.target.value !== "OTHER") {
-                  setOtherEducationType("");
-                }
               }}
               className="flex flex-wrap gap-4"
             >
@@ -166,14 +150,6 @@ export default function ManagerSafetyEducationCreatePage() {
               <Radio value="SPECIAL">특별교육</Radio>
               <Radio value="OTHER">기타</Radio>
             </Radio.Group>
-            {educationType === "OTHER" && (
-              <Input
-                value={otherEducationType}
-                onChange={(e) => setOtherEducationType(e.target.value)}
-                placeholder="기타 선택 시 직접 입력"
-                className="mt-3 rounded-lg"
-              />
-            )}
           </div>
 
           <div>

--- a/src/app/(manager)/manager/safety-education/create/select/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/select/page.tsx
@@ -23,8 +23,17 @@ export default function ManagerSafetyEducationSelectPage() {
 
   const { data: siteDetail } = useSiteDetail(parsedSiteId);
 
-  // Query params에서 교육 정보 가져오기
+  // 세션 스토리지에서 교육 정보 가져오기 (긴 텍스트를 URL에 포함하지 않기 위해)
   const educationData = useMemo(() => {
+    const storedData = sessionStorage.getItem("safety-education-form-data");
+    if (storedData) {
+      try {
+        return JSON.parse(storedData);
+      } catch (e) {
+        console.error("Failed to parse education data from sessionStorage", e);
+      }
+    }
+    // 폴백: 쿼리 파라미터에서 가져오기 (하위 호환성)
     return {
       siteName: searchParams.get("siteName") ?? "",
       siteAddress: searchParams.get("siteAddress") ?? "",
@@ -74,6 +83,7 @@ export default function ManagerSafetyEducationSelectPage() {
   };
 
   const handleBack = () => {
+    // 세션 스토리지는 유지 (뒤로 가기 시 데이터 보존)
     router.back();
   };
 
@@ -87,14 +97,19 @@ export default function ManagerSafetyEducationSelectPage() {
       return;
     }
 
-    // 선택된 근로자 ID 배열을 query params로 전달
+    // 선택된 근로자 ID 배열을 세션 스토리지에 추가
     const selectedEmployeeIdsArray = Array.from(selectedEmployeeIds);
+    const updatedEducationData = {
+      ...educationData,
+      selectedEmployeeIds: selectedEmployeeIdsArray,
+    };
+    sessionStorage.setItem("safety-education-form-data", JSON.stringify(updatedEducationData));
 
-    const params = new URLSearchParams();
-    Object.entries(educationData).forEach(([key, value]) => {
-      params.set(key, value);
+    // 다음 단계로 이동 (짧은 정보만 query params로 전달)
+    const params = new URLSearchParams({
+      educationType: educationData.educationType,
+      educationSubject: educationData.educationSubject,
     });
-    params.set("selectedEmployeeIds", JSON.stringify(selectedEmployeeIdsArray));
 
     router.push(`/manager/safety-education/create/sign?${params.toString()}`);
   };

--- a/src/app/(manager)/manager/safety-education/create/select/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/select/page.tsx
@@ -173,11 +173,18 @@ export default function ManagerSafetyEducationSelectPage() {
           rowSelection={{
             selectedRowKeys: Array.from(selectedEmployeeIds),
             onSelectAll: (selected) => {
+              const newSet = new Set(selectedEmployeeIds);
+              const currentEmployeeIds = employees.map((emp) => emp.employeeId);
+
               if (selected) {
-                setSelectedEmployeeIds(new Set(employees.map((emp) => emp.employeeId)));
+                // 현재 보이는 근로자들을 기존 선택에 추가 (merge)
+                currentEmployeeIds.forEach((id) => newSet.add(id));
               } else {
-                setSelectedEmployeeIds(new Set());
+                // 현재 보이는 근로자들만 해제 (다른 필터의 선택은 유지)
+                currentEmployeeIds.forEach((id) => newSet.delete(id));
               }
+
+              setSelectedEmployeeIds(newSet);
             },
             onSelect: (record, selected) => {
               const newSet = new Set(selectedEmployeeIds);

--- a/src/app/(manager)/manager/safety-education/create/select/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/select/page.tsx
@@ -51,7 +51,7 @@ export default function ManagerSafetyEducationSelectPage() {
   const [employmentFilter, setEmploymentFilter] = useState<EmploymentFilterValue>("ALL");
   const [selectedEmployeeIds, setSelectedEmployeeIds] = useState<Set<number>>(new Set());
 
-  // 근로자 목록 조회
+  // 근로자 목록 조회 (필터링용)
   const empType: "ALL" | "PERMANENT" | "DAILY" =
     employmentFilter === "ALL" ? "ALL" : employmentFilter === "REGULAR" ? "PERMANENT" : "DAILY";
 
@@ -67,10 +67,23 @@ export default function ManagerSafetyEducationSelectPage() {
 
   const employees = useMemo(() => employeesData?.items ?? [], [employeesData?.items]);
 
-  // 선택된 근로자 통계
+  // 전체 근로자 목록 조회 (통계 계산용 - 필터와 관계없이 모든 선택된 근로자 통계 표시)
+  const { data: allEmployeesData } = useSafetyEducationLogEmployees(
+    {
+      siteId: parsedSiteId,
+      empType: "ALL",
+    },
+    {
+      enabled: hasValidSiteId,
+    },
+  );
+
+  const allEmployees = useMemo(() => allEmployeesData?.items ?? [], [allEmployeesData?.items]);
+
+  // 선택된 근로자 통계 (전체 근로자 목록 기준으로 계산)
   const selectedEmployees = useMemo(() => {
-    return employees.filter((emp) => selectedEmployeeIds.has(emp.employeeId));
-  }, [employees, selectedEmployeeIds]);
+    return allEmployees.filter((emp) => selectedEmployeeIds.has(emp.employeeId));
+  }, [allEmployees, selectedEmployeeIds]);
 
   const selectedCount = selectedEmployees.length;
   const selectedRegularCount = selectedEmployees.filter(

--- a/src/app/(manager)/manager/safety-education/create/select/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/select/page.tsx
@@ -2,23 +2,17 @@
 
 import { useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Input, notification } from "antd";
+import { notification } from "antd";
 import { Button } from "@/components/ui/Button/button";
 import { Table } from "@/components/ui/Table/table";
 import {
   EmploymentTypeFilterChips,
   type EmploymentFilterValue,
 } from "@/components/features/manager/employment-type-filter-chips";
-import { useEmployees } from "@/hooks/use-employees";
+import { useSafetyEducationLogEmployees } from "@/hooks/use-safety-education-log-employees";
 import { useSiteDetail } from "@/hooks/use-site-detail";
 import { useSessionStore } from "@/stores/session-store";
-import type { EmployeeRecord, EmploymentType } from "@/types/employee";
-
-type SelectedEmployee = {
-  employeeId: number;
-  name: string;
-  employmentType: EmploymentType;
-};
+import type { SafetyEducationLogEmployee } from "@/lib/api/get-safety-education-log-employees";
 
 export default function ManagerSafetyEducationSelectPage() {
   const router = useRouter();
@@ -46,43 +40,34 @@ export default function ManagerSafetyEducationSelectPage() {
   }, [searchParams]);
 
   const [employmentFilter, setEmploymentFilter] = useState<EmploymentFilterValue>("ALL");
-  const [searchKeyword, setSearchKeyword] = useState("");
-  const [page, setPage] = useState(1);
-  const pageSize = 20;
   const [selectedEmployeeIds, setSelectedEmployeeIds] = useState<Set<number>>(new Set());
 
   // 근로자 목록 조회
-  const employmentType: EmploymentType | undefined =
-    employmentFilter === "ALL" ? undefined : employmentFilter;
+  const empType: "ALL" | "PERMANENT" | "DAILY" =
+    employmentFilter === "ALL" ? "ALL" : employmentFilter === "REGULAR" ? "PERMANENT" : "DAILY";
 
-  const { data: employeesData, isLoading: isLoadingEmployees } = useEmployees(
+  const { data: employeesData, isLoading: isLoadingEmployees } = useSafetyEducationLogEmployees(
     {
       siteId: parsedSiteId,
-      employmentType,
-      page,
-      size: pageSize,
-      searchKeyword: searchKeyword || undefined,
+      empType,
     },
     {
       enabled: hasValidSiteId,
     },
   );
 
-  const employees = useMemo(() => employeesData?.records ?? [], [employeesData?.records]);
-  const totalCount = employeesData?.pagination.totalRecords ?? 0;
+  const employees = useMemo(() => employeesData?.items ?? [], [employeesData?.items]);
 
   // 선택된 근로자 통계
   const selectedEmployees = useMemo(() => {
-    return employees.filter((emp) => selectedEmployeeIds.has(emp.id));
+    return employees.filter((emp) => selectedEmployeeIds.has(emp.employeeId));
   }, [employees, selectedEmployeeIds]);
 
   const selectedCount = selectedEmployees.length;
   const selectedRegularCount = selectedEmployees.filter(
-    (emp) => emp.employmentType === "REGULAR",
+    (emp) => emp.empType === "PERMANENT",
   ).length;
-  const selectedDailyCount = selectedEmployees.filter(
-    (emp) => emp.employmentType === "DAILY",
-  ).length;
+  const selectedDailyCount = selectedEmployees.filter((emp) => emp.empType === "DAILY").length;
 
   const handleResetSelection = () => {
     setSelectedEmployeeIds(new Set());
@@ -102,28 +87,16 @@ export default function ManagerSafetyEducationSelectPage() {
       return;
     }
 
-    // 선택된 근로자 정보를 query params로 전달
-    const selectedEmployeesData: SelectedEmployee[] = employees
-      .filter((emp) => selectedEmployeeIds.has(emp.id))
-      .map((emp) => ({
-        employeeId: emp.id,
-        name: emp.name,
-        employmentType: emp.employmentType,
-      }));
+    // 선택된 근로자 ID 배열을 query params로 전달
+    const selectedEmployeeIdsArray = Array.from(selectedEmployeeIds);
 
     const params = new URLSearchParams();
     Object.entries(educationData).forEach(([key, value]) => {
       params.set(key, value);
     });
-    params.set("selectedEmployees", JSON.stringify(selectedEmployeesData));
+    params.set("selectedEmployeeIds", JSON.stringify(selectedEmployeeIdsArray));
 
     router.push(`/manager/safety-education/create/sign?${params.toString()}`);
-  };
-
-  // TODO: 안전교육이수 여부는 API에서 받아와야 함
-  const hasCompletedSafetyEducation = (employeeId: number): boolean => {
-    // 임시로 일부 근로자만 이수한 것으로 표시
-    return employeeId % 3 === 0;
   };
 
   return (
@@ -156,67 +129,24 @@ export default function ManagerSafetyEducationSelectPage() {
               value={employmentFilter}
               onChange={(value) => {
                 setEmploymentFilter(value);
-                setPage(1);
               }}
             />
-            <div className="flex items-center gap-2">
-              <Input
-                value={searchKeyword}
-                onChange={(e) => {
-                  setSearchKeyword(e.target.value);
-                  setPage(1);
-                }}
-                placeholder="근로자명 또는 연락처로 검색"
-                className="w-64 rounded-lg"
-                prefix={
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M7.33333 12.6667C10.2789 12.6667 12.6667 10.2789 12.6667 7.33333C12.6667 4.38781 10.2789 2 7.33333 2C4.38781 2 2 4.38781 2 7.33333C2 10.2789 4.38781 12.6667 7.33333 12.6667Z"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M14 14L11.1 11.1"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                }
-              />
-            </div>
           </div>
         </div>
       </section>
 
       {/* 근로자 선택 테이블 */}
       <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
-        <Table<EmployeeRecord>
+        <Table<SafetyEducationLogEmployee>
           dataSource={employees}
           loading={isLoadingEmployees}
-          rowKey={(record) => record.id}
-          pagination={{
-            current: page,
-            pageSize,
-            total: totalCount,
-            onChange: (newPage) => setPage(newPage),
-            position: ["bottomCenter"],
-            showSizeChanger: false,
-          }}
+          rowKey={(record) => record.employeeId}
+          pagination={false}
           rowSelection={{
             selectedRowKeys: Array.from(selectedEmployeeIds),
             onSelectAll: (selected) => {
               if (selected) {
-                setSelectedEmployeeIds(new Set(employees.map((emp) => emp.id)));
+                setSelectedEmployeeIds(new Set(employees.map((emp) => emp.employeeId)));
               } else {
                 setSelectedEmployeeIds(new Set());
               }
@@ -224,9 +154,9 @@ export default function ManagerSafetyEducationSelectPage() {
             onSelect: (record, selected) => {
               const newSet = new Set(selectedEmployeeIds);
               if (selected) {
-                newSet.add(record.id);
+                newSet.add(record.employeeId);
               } else {
-                newSet.delete(record.id);
+                newSet.delete(record.employeeId);
               }
               setSelectedEmployeeIds(newSet);
             },
@@ -234,15 +164,15 @@ export default function ManagerSafetyEducationSelectPage() {
           columns={[
             {
               title: "구분",
-              dataIndex: "employmentType",
-              key: "employmentType",
+              dataIndex: "empType",
+              key: "empType",
               align: "center",
-              render: (type: EmploymentType) => (type === "REGULAR" ? "상용" : "일용"),
+              render: (type: "PERMANENT" | "DAILY") => (type === "PERMANENT" ? "상용" : "일용"),
             },
             {
               title: "사원",
-              dataIndex: "name",
-              key: "name",
+              dataIndex: "empName",
+              key: "empName",
               align: "center",
             },
             {
@@ -253,59 +183,22 @@ export default function ManagerSafetyEducationSelectPage() {
                   여부
                 </>
               ),
-              key: "safetyEducation",
+              dataIndex: "hasSafetyEducation",
+              key: "hasSafetyEducation",
               align: "center",
-              render: (_, record) => {
-                const hasCompleted = hasCompletedSafetyEducation(record.id);
-                return hasCompleted ? (
+              render: (hasCompleted: boolean) =>
+                hasCompleted ? (
                   <span className="text-state-success">○</span>
                 ) : (
                   <span className="text-state-danger">×</span>
-                );
-              },
-            },
-            {
-              title: "입사일",
-              key: "joinDate",
-              align: "center",
-              render: () => "-", // TODO: 입사일 정보 필요
-            },
-            {
-              title: "퇴사일",
-              key: "resignDate",
-              align: "center",
-              render: () => "-", // TODO: 퇴사일 정보 필요
+                ),
             },
             {
               title: "주민등록번호",
-              dataIndex: "residentNumber",
-              key: "residentNumber",
+              dataIndex: "residentNum",
+              key: "residentNum",
               align: "center",
-              render: (value) => value || "-",
-            },
-            {
-              title: "연락처",
-              key: "phone",
-              align: "center",
-              render: () => "-", // TODO: 연락처 정보 필요
-            },
-            {
-              title: "이메일",
-              key: "email",
-              align: "center",
-              render: () => "-", // TODO: 이메일 정보 필요
-            },
-            {
-              title: "주소",
-              key: "address",
-              align: "center",
-              render: () => "-", // TODO: 주소 정보 필요
-            },
-            {
-              title: "비상연락망",
-              key: "emergencyContact",
-              align: "center",
-              render: () => "-", // TODO: 비상연락망 정보 필요
+              render: (value: string) => value || "-",
             },
           ]}
           showHeaderBar={false}

--- a/src/app/(manager)/manager/safety-education/create/select/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/select/page.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Input, notification } from "antd";
+import { Button } from "@/components/ui/Button/button";
+import { Table } from "@/components/ui/Table/table";
+import {
+  EmploymentTypeFilterChips,
+  type EmploymentFilterValue,
+} from "@/components/features/manager/employment-type-filter-chips";
+import { useEmployees } from "@/hooks/use-employees";
+import { useSiteDetail } from "@/hooks/use-site-detail";
+import { useSessionStore } from "@/stores/session-store";
+import type { EmployeeRecord, EmploymentType } from "@/types/employee";
+
+type SelectedEmployee = {
+  employeeId: number;
+  name: string;
+  employmentType: EmploymentType;
+};
+
+export default function ManagerSafetyEducationSelectPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const user = useSessionStore((state) => state.user);
+  const parsedSiteId = user?.siteId ?? 0;
+  const hasValidSiteId = !!parsedSiteId && !Number.isNaN(parsedSiteId);
+
+  const { data: siteDetail } = useSiteDetail(parsedSiteId);
+
+  // Query params에서 교육 정보 가져오기
+  const educationData = useMemo(() => {
+    return {
+      siteName: searchParams.get("siteName") ?? "",
+      siteAddress: searchParams.get("siteAddress") ?? "",
+      educationDate: searchParams.get("educationDate") ?? "",
+      author: searchParams.get("author") ?? "",
+      educationType: searchParams.get("educationType") ?? "",
+      otherEducationType: searchParams.get("otherEducationType") ?? "",
+      educationSubject: searchParams.get("educationSubject") ?? "",
+      educationContent: searchParams.get("educationContent") ?? "",
+      instructorName: searchParams.get("instructorName") ?? "",
+      educationLocation: searchParams.get("educationLocation") ?? "",
+    };
+  }, [searchParams]);
+
+  const [employmentFilter, setEmploymentFilter] = useState<EmploymentFilterValue>("ALL");
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [page, setPage] = useState(1);
+  const pageSize = 20;
+  const [selectedEmployeeIds, setSelectedEmployeeIds] = useState<Set<number>>(new Set());
+
+  // 근로자 목록 조회
+  const employmentType: EmploymentType | undefined =
+    employmentFilter === "ALL" ? undefined : employmentFilter;
+
+  const { data: employeesData, isLoading: isLoadingEmployees } = useEmployees(
+    {
+      siteId: parsedSiteId,
+      employmentType,
+      page,
+      size: pageSize,
+      searchKeyword: searchKeyword || undefined,
+    },
+    {
+      enabled: hasValidSiteId,
+    },
+  );
+
+  const employees = useMemo(() => employeesData?.records ?? [], [employeesData?.records]);
+  const totalCount = employeesData?.pagination.totalRecords ?? 0;
+
+  // 선택된 근로자 통계
+  const selectedEmployees = useMemo(() => {
+    return employees.filter((emp) => selectedEmployeeIds.has(emp.id));
+  }, [employees, selectedEmployeeIds]);
+
+  const selectedCount = selectedEmployees.length;
+  const selectedRegularCount = selectedEmployees.filter(
+    (emp) => emp.employmentType === "REGULAR",
+  ).length;
+  const selectedDailyCount = selectedEmployees.filter(
+    (emp) => emp.employmentType === "DAILY",
+  ).length;
+
+  const handleResetSelection = () => {
+    setSelectedEmployeeIds(new Set());
+  };
+
+  const handleBack = () => {
+    router.back();
+  };
+
+  const handleNext = () => {
+    if (selectedEmployeeIds.size === 0) {
+      notification.warning({
+        message: "교육 대상자를 최소 1명 이상 선택해주세요.",
+        placement: "topRight",
+        duration: 3,
+      });
+      return;
+    }
+
+    // 선택된 근로자 정보를 query params로 전달
+    const selectedEmployeesData: SelectedEmployee[] = employees
+      .filter((emp) => selectedEmployeeIds.has(emp.id))
+      .map((emp) => ({
+        employeeId: emp.id,
+        name: emp.name,
+        employmentType: emp.employmentType,
+      }));
+
+    const params = new URLSearchParams();
+    Object.entries(educationData).forEach(([key, value]) => {
+      params.set(key, value);
+    });
+    params.set("selectedEmployees", JSON.stringify(selectedEmployeesData));
+
+    router.push(`/manager/safety-education/create/sign?${params.toString()}`);
+  };
+
+  // TODO: 안전교육이수 여부는 API에서 받아와야 함
+  const hasCompletedSafetyEducation = (employeeId: number): boolean => {
+    // 임시로 일부 근로자만 이수한 것으로 표시
+    return employeeId % 3 === 0;
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-lg border border-border bg-bg-surface p-3 dark:border-dark-border dark:bg-dark-bg-surface">
+        <header className="space-y-1">
+          <h1 className="mb-0! text-2xl font-semibold! text-text-strong dark:text-dark-text-strong">
+            {siteDetail?.siteName ?? "현장 이름을 불러오는 중..."}
+          </h1>
+          <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
+            {siteDetail?.siteAddress ?? "현장 주소를 불러오는 중입니다."}
+          </p>
+        </header>
+      </section>
+
+      <header className="ml-3 space-y-1">
+        <h2 className="mb-0! text-2xl font-semibold! text-brand-primary-strong dark:text-dark-text-strong">
+          안전교육 대상자 선택
+        </h2>
+        <p className="mb-0! text-sm text-text-subtle dark:text-dark-text-base">
+          안전교육을 받은 근로자를 아래 표에서 선택하세요.
+        </p>
+      </header>
+
+      {/* 필터 영역 */}
+      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <EmploymentTypeFilterChips
+              value={employmentFilter}
+              onChange={(value) => {
+                setEmploymentFilter(value);
+                setPage(1);
+              }}
+            />
+            <div className="flex items-center gap-2">
+              <Input
+                value={searchKeyword}
+                onChange={(e) => {
+                  setSearchKeyword(e.target.value);
+                  setPage(1);
+                }}
+                placeholder="근로자명 또는 연락처로 검색"
+                className="w-64 rounded-lg"
+                prefix={
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M7.33333 12.6667C10.2789 12.6667 12.6667 10.2789 12.6667 7.33333C12.6667 4.38781 10.2789 2 7.33333 2C4.38781 2 2 4.38781 2 7.33333C2 10.2789 4.38781 12.6667 7.33333 12.6667Z"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M14 14L11.1 11.1"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 근로자 선택 테이블 */}
+      <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
+        <Table<EmployeeRecord>
+          dataSource={employees}
+          loading={isLoadingEmployees}
+          rowKey={(record) => record.id}
+          pagination={{
+            current: page,
+            pageSize,
+            total: totalCount,
+            onChange: (newPage) => setPage(newPage),
+            position: ["bottomCenter"],
+            showSizeChanger: false,
+          }}
+          rowSelection={{
+            selectedRowKeys: Array.from(selectedEmployeeIds),
+            onSelectAll: (selected) => {
+              if (selected) {
+                setSelectedEmployeeIds(new Set(employees.map((emp) => emp.id)));
+              } else {
+                setSelectedEmployeeIds(new Set());
+              }
+            },
+            onSelect: (record, selected) => {
+              const newSet = new Set(selectedEmployeeIds);
+              if (selected) {
+                newSet.add(record.id);
+              } else {
+                newSet.delete(record.id);
+              }
+              setSelectedEmployeeIds(newSet);
+            },
+          }}
+          columns={[
+            {
+              title: "구분",
+              dataIndex: "employmentType",
+              key: "employmentType",
+              align: "center",
+              render: (type: EmploymentType) => (type === "REGULAR" ? "상용" : "일용"),
+            },
+            {
+              title: "사원",
+              dataIndex: "name",
+              key: "name",
+              align: "center",
+            },
+            {
+              title: (
+                <>
+                  안전교육이수
+                  <br />
+                  여부
+                </>
+              ),
+              key: "safetyEducation",
+              align: "center",
+              render: (_, record) => {
+                const hasCompleted = hasCompletedSafetyEducation(record.id);
+                return hasCompleted ? (
+                  <span className="text-state-success">○</span>
+                ) : (
+                  <span className="text-state-danger">×</span>
+                );
+              },
+            },
+            {
+              title: "입사일",
+              key: "joinDate",
+              align: "center",
+              render: () => "-", // TODO: 입사일 정보 필요
+            },
+            {
+              title: "퇴사일",
+              key: "resignDate",
+              align: "center",
+              render: () => "-", // TODO: 퇴사일 정보 필요
+            },
+            {
+              title: "주민등록번호",
+              dataIndex: "residentNumber",
+              key: "residentNumber",
+              align: "center",
+              render: (value) => value || "-",
+            },
+            {
+              title: "연락처",
+              key: "phone",
+              align: "center",
+              render: () => "-", // TODO: 연락처 정보 필요
+            },
+            {
+              title: "이메일",
+              key: "email",
+              align: "center",
+              render: () => "-", // TODO: 이메일 정보 필요
+            },
+            {
+              title: "주소",
+              key: "address",
+              align: "center",
+              render: () => "-", // TODO: 주소 정보 필요
+            },
+            {
+              title: "비상연락망",
+              key: "emergencyContact",
+              align: "center",
+              render: () => "-", // TODO: 비상연락망 정보 필요
+            },
+          ]}
+          showHeaderBar={false}
+          borderedContainer={false}
+          className="rounded-2xl border border-border bg-white dark:border-dark-border dark:bg-dark-bg-surface"
+        />
+      </section>
+
+      {/* 선택된 근로자 통계 */}
+      <section className="rounded-2xl border border-border bg-[#f8f9fb] px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+        <div className="grid grid-cols-3 gap-4">
+          <div className="text-center">
+            <p className="mb-1 text-sm text-brand-primary-strong">선택된 근로자 수</p>
+            <p className="text-lg font-medium text-brand-primary">{selectedCount}명</p>
+          </div>
+          <div className="text-center">
+            <p className="mb-1 text-sm text-brand-primary-strong">상용 근로자</p>
+            <p className="text-lg font-medium text-brand-primary">{selectedRegularCount}명</p>
+          </div>
+          <div className="text-center">
+            <p className="mb-1 text-sm text-brand-primary-strong">일용 근로자</p>
+            <p className="text-lg font-medium text-brand-primary">{selectedDailyCount}명</p>
+          </div>
+        </div>
+      </section>
+
+      {/* 하단 액션 버튼 */}
+      <section className="flex justify-end gap-3">
+        <Button variant="secondary" size="md" onClick={handleBack}>
+          이전 단계
+        </Button>
+        <Button variant="secondary" size="md" onClick={handleResetSelection}>
+          선택 초기화
+        </Button>
+        <Button variant="primary" size="md" onClick={handleNext}>
+          다음 단계로
+        </Button>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(manager)/manager/safety-education/create/sign/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/sign/page.tsx
@@ -320,6 +320,16 @@ export default function ManagerSafetyEducationSignPage() {
       return;
     }
 
+    // 참석자가 없는 경우 체크 (every()는 빈 배열에 대해 true를 반환하므로)
+    if (attendeesData.attendees.length === 0) {
+      notification.error({
+        message:
+          "교육 대상자가 선택되지 않았습니다. 이전 단계로 돌아가서 교육 대상자를 선택해주세요.",
+        placement: "topRight",
+      });
+      return;
+    }
+
     // 모든 근로자가 서명 완료되었는지 확인
     const allSigned = attendeesData.attendees.every((attendee) => attendee.isSigned);
     if (!allSigned) {

--- a/src/app/(manager)/manager/safety-education/create/sign/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/sign/page.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Input, notification } from "antd";
+import SignatureCanvas from "react-signature-canvas";
+import dayjs from "dayjs";
+
+import { PDFViewer } from "@/components/common/pdf-viewer";
+import { Button } from "@/components/ui/Button/button";
+import { StatusPill } from "@/components/ui/StatusPill/status-pill";
+import { useSiteDetail } from "@/hooks/use-site-detail";
+import { useSessionStore } from "@/stores/session-store";
+import { useQuery } from "@tanstack/react-query";
+import { useCreateSafetyEducationReport } from "@/hooks/use-create-safety-education-report";
+import { handleSafetyEducationManagerSignature } from "@/lib/api/safety-education-signature";
+import { getSafetyEducationReportPdfUrl } from "@/lib/api/get-safety-education-report-pdf";
+
+type SelectedEmployee = {
+  employeeId: number;
+  name: string;
+  employmentType: "REGULAR" | "DAILY";
+};
+
+export default function ManagerSafetyEducationSignPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const user = useSessionStore((state) => state.user);
+  const parsedSiteId = user?.siteId ?? 0;
+  const hasValidSiteId = !!parsedSiteId && !Number.isNaN(parsedSiteId);
+
+  const { data: siteDetail } = useSiteDetail(parsedSiteId);
+
+  const signaturePadRef = useRef<SignatureCanvas | null>(null);
+  const [hasSignature, setHasSignature] = useState(false);
+
+  // Query params에서 교육 정보 및 선택된 근로자 가져오기
+  const educationData = useMemo(() => {
+    const selectedEmployeesJson = searchParams.get("selectedEmployees");
+    let selectedEmployees: SelectedEmployee[] = [];
+    if (selectedEmployeesJson) {
+      try {
+        selectedEmployees = JSON.parse(selectedEmployeesJson);
+      } catch (e) {
+        console.error("Failed to parse selectedEmployees", e);
+      }
+    }
+
+    return {
+      siteName: searchParams.get("siteName") ?? "",
+      siteAddress: searchParams.get("siteAddress") ?? "",
+      educationDate: searchParams.get("educationDate") ?? "",
+      author: searchParams.get("author") ?? "",
+      educationType: searchParams.get("educationType") ?? "",
+      otherEducationType: searchParams.get("otherEducationType") ?? "",
+      educationSubject: searchParams.get("educationSubject") ?? "",
+      educationContent: searchParams.get("educationContent") ?? "",
+      instructorName: searchParams.get("instructorName") ?? "",
+      educationLocation: searchParams.get("educationLocation") ?? "",
+      selectedEmployees,
+    };
+  }, [searchParams]);
+
+  const signerName = user?.name ?? "";
+  const signDate = dayjs().format("YYYY-MM-DD");
+
+  const [reportId, setReportId] = useState<number | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const hasCreatedRef = useRef(false);
+
+  const createReportMutation = useCreateSafetyEducationReport(parsedSiteId, {
+    onSuccess: (data) => {
+      setReportId(data.safetyEducationReportId);
+      setIsCreating(false);
+      notification.success({
+        message: "안전교육 일지가 생성되었습니다.",
+        placement: "topRight",
+      });
+    },
+    onError: (error) => {
+      setIsCreating(false);
+      notification.error({
+        message: error.message || "안전교육 일지를 생성하는 중 오류가 발생했습니다.",
+        placement: "topRight",
+      });
+    },
+  });
+
+  // 페이지 로드 시 안전교육 일지 생성 (한 번만 실행)
+  useEffect(() => {
+    if (
+      !hasCreatedRef.current &&
+      !isCreating &&
+      !reportId &&
+      hasValidSiteId &&
+      educationData.selectedEmployees.length > 0 &&
+      !createReportMutation.isPending
+    ) {
+      hasCreatedRef.current = true;
+      setIsCreating(true);
+      createReportMutation.mutate({
+        educationDate: educationData.educationDate,
+        educationType: educationData.educationType as
+          | "REGULAR"
+          | "HIRING"
+          | "WORK_CHANGE"
+          | "SPECIAL"
+          | "OTHER",
+        otherEducationType:
+          educationData.educationType === "OTHER" ? educationData.otherEducationType : undefined,
+        educationSubject: educationData.educationSubject,
+        educationContent: educationData.educationContent,
+        instructorName: educationData.instructorName,
+        educationLocation: educationData.educationLocation,
+        participants: educationData.selectedEmployees,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasValidSiteId, educationData.selectedEmployees.length]);
+
+  const { data: pdfUrl, isLoading: isPdfLoading } = useQuery({
+    queryKey: ["safety-education-report-pdf", parsedSiteId, reportId],
+    queryFn: () => {
+      if (reportId == null) {
+        return Promise.reject(new Error("안전교육 일지 ID가 없습니다."));
+      }
+      return getSafetyEducationReportPdfUrl(parsedSiteId, reportId);
+    },
+    enabled: reportId != null && hasValidSiteId,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  useEffect(() => {
+    const resize = () => {
+      if (!signaturePadRef.current) return;
+      const canvas = signaturePadRef.current.getCanvas();
+      if (!canvas) return;
+
+      const ratio = window.devicePixelRatio || 1;
+      const w = canvas.clientWidth;
+      const h = canvas.clientHeight;
+
+      canvas.width = Math.round(w * ratio);
+      canvas.height = Math.round(h * ratio);
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+
+      const ctx = canvas.getContext("2d");
+      ctx?.setTransform(ratio, 0, 0, ratio, 0, 0);
+    };
+
+    const timeoutId = setTimeout(resize, 100);
+    window.addEventListener("resize", resize);
+
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
+
+  const handleSignatureClear = () => {
+    signaturePadRef.current?.clear();
+    setHasSignature(false);
+  };
+
+  const handleSignatureSave = async () => {
+    const pad = signaturePadRef.current;
+    if (!pad || pad.isEmpty()) {
+      notification.warning({
+        message: "서명을 입력해주세요.",
+        placement: "topRight",
+      });
+      return;
+    }
+
+    if (!reportId) {
+      notification.error({
+        message: "안전교육 일지가 생성되지 않았습니다. 잠시 후 다시 시도해주세요.",
+        placement: "topRight",
+      });
+      return;
+    }
+
+    try {
+      const dataUrl = pad.toDataURL("image/png");
+      await handleSafetyEducationManagerSignature(parsedSiteId, reportId, dataUrl);
+
+      notification.success({
+        message: "담당자 서명이 저장되었습니다.",
+        placement: "topRight",
+      });
+
+      setHasSignature(false);
+      pad.clear();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "담당자 서명을 처리하는 중 오류가 발생했습니다.";
+      notification.error({
+        message,
+        placement: "topRight",
+      });
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!reportId) {
+      notification.warning({
+        message: "안전교육 일지가 생성되지 않았습니다.",
+        placement: "topRight",
+      });
+      return;
+    }
+    router.push("/manager/safety-education?created=true");
+  };
+
+  const handlePrint = () => {
+    window.print();
+  };
+
+  const handleDownloadPdf = () => {
+    if (pdfUrl) {
+      window.open(pdfUrl, "_blank");
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-lg border border-border bg-bg-surface p-3 dark:border-dark-border dark:bg-dark-bg-surface">
+        <header className="space-y-1">
+          <h1 className="mb-0! text-2xl font-semibold! text-text-strong dark:text-dark-text-strong">
+            {siteDetail?.siteName ?? "현장 이름을 불러오는 중..."}
+          </h1>
+          <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
+            {siteDetail?.siteAddress ?? "현장 주소를 불러오는 중입니다."}
+          </p>
+        </header>
+      </section>
+
+      <header className="ml-3 space-y-1">
+        <h2 className="mb-0! text-2xl font-semibold! text-brand-primary-strong dark:text-dark-text-strong">
+          안전교육일지 서명
+        </h2>
+        <p className="mb-0! text-sm text-text-subtle dark:text-dark-text-base">
+          아래는 자동 생성된 안전교육 일지입니다. 담당자 서명 후 문서를 저장하세요.
+        </p>
+      </header>
+
+      {/* 교육 기본 정보 */}
+      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+        <div className="grid grid-cols-2 gap-6">
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">교육 일자</label>
+            <Input
+              value={dayjs(educationData.educationDate).format("YYYY-MM-DD")}
+              disabled
+              className="rounded-lg"
+            />
+          </div>
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">작성자</label>
+            <Input value={educationData.author} disabled className="rounded-lg" />
+          </div>
+        </div>
+      </section>
+
+      {/* 문서 미리보기 */}
+      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="mb-0 text-lg font-normal text-brand-primary-strong">문서 미리보기</h3>
+          <div className="flex gap-2">
+            <Button variant="secondary" size="md" onClick={handlePrint}>
+              인쇄
+            </Button>
+            <Button variant="primary" size="md" onClick={handleDownloadPdf}>
+              PDF 다운로드
+            </Button>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-border bg-[#f9fafb] p-4 dark:border-dark-border dark:bg-dark-bg-surface">
+          {isCreating ? (
+            <div className="flex h-[480px] items-center justify-center text-text-subtle">
+              안전교육 일지를 생성하는 중...
+            </div>
+          ) : isPdfLoading ? (
+            <div className="flex h-[480px] items-center justify-center text-text-subtle">
+              PDF를 불러오는 중...
+            </div>
+          ) : pdfUrl ? (
+            <PDFViewer pdfUrl={pdfUrl} />
+          ) : (
+            <div className="flex h-[480px] flex-col items-center justify-center text-text-subtle">
+              <svg
+                width="60"
+                height="60"
+                viewBox="0 0 60 60"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="mb-4 opacity-50"
+              >
+                <path
+                  d="M15 5H35L45 15V50C45 52.7614 42.7614 55 40 55H15C12.2386 55 10 52.7614 10 50V10C10 7.23858 12.2386 5 15 5Z"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M35 5V15H45"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <p className="mb-2 text-base">PDF 문서 미리보기</p>
+              <p className="text-sm">A4 형태의 안전교육일지가 표시됩니다</p>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* 담당자 서명 */}
+      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+        <h3 className="mb-4 text-lg font-normal text-brand-primary-strong">담당자 서명</h3>
+        <div className="grid grid-cols-2 gap-6">
+          <div className="space-y-4">
+            <div>
+              <label className="mb-2 block text-sm text-brand-primary-strong">서명자 이름</label>
+              <Input value={signerName} disabled className="rounded-lg" />
+            </div>
+            <div>
+              <label className="mb-2 block text-sm text-brand-primary-strong">서명일자</label>
+              <Input value={signDate} disabled className="rounded-lg" />
+            </div>
+          </div>
+          <div>
+            <label className="mb-2 block text-sm text-brand-primary-strong">서명 입력란</label>
+            <div className="relative rounded-xl border border-[#d1d5db] bg-[#f9fafb] p-4">
+              <SignatureCanvas
+                ref={signaturePadRef}
+                canvasProps={{
+                  className: "w-full h-48 border-0 bg-transparent",
+                }}
+                onEnd={() => setHasSignature(true)}
+              />
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                {!hasSignature && (
+                  <div className="text-center text-text-subtle">
+                    <Image
+                      src="/assets/icons/signature.svg"
+                      alt="서명"
+                      width={30}
+                      height={30}
+                      className="mx-auto mb-2 opacity-30"
+                    />
+                    <p className="text-sm italic">여기에 서명하세요</p>
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="mt-2 flex gap-2">
+              <Button variant="secondary" size="md" onClick={handleSignatureClear}>
+                서명 지우기
+              </Button>
+              <Button variant="primary" size="md" onClick={handleSignatureSave}>
+                서명 저장하기
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 교육 대상자 서명 현황 */}
+      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+        <h3 className="mb-4 text-lg font-normal text-brand-primary-strong">
+          교육 대상자 서명 현황
+        </h3>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse rounded-lg">
+            <thead>
+              <tr className="bg-[#f9fafb]">
+                <th className="border border-[#e1e5ea] px-4 py-3 text-center text-sm font-normal text-brand-primary-strong">
+                  구분
+                </th>
+                <th className="border border-[#e1e5ea] px-4 py-3 text-center text-sm font-normal text-brand-primary-strong">
+                  교육 대상자
+                </th>
+                <th className="border border-[#e1e5ea] px-4 py-3 text-center text-sm font-normal text-brand-primary-strong">
+                  주민등록번호
+                </th>
+                <th className="border border-[#e1e5ea] px-4 py-3 text-center text-sm font-normal text-brand-primary-strong">
+                  상태
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {educationData.selectedEmployees.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="border border-[#e1e5ea] px-4 py-8 text-center text-text-subtle"
+                  >
+                    선택된 교육 대상자가 없습니다.
+                  </td>
+                </tr>
+              ) : (
+                educationData.selectedEmployees.map((employee, index) => {
+                  // TODO: 실제 서명 상태는 API에서 받아와야 함
+                  const isSigned = index % 2 === 0; // 임시로 일부만 서명 완료로 표시
+
+                  return (
+                    <tr key={employee.employeeId}>
+                      <td className="border border-[#e1e5ea] px-4 py-4 text-center text-sm text-text-strong">
+                        {employee.employmentType === "REGULAR" ? "상용" : "일용"}
+                      </td>
+                      <td className="border border-[#e1e5ea] px-4 py-4 text-center text-sm text-text-strong">
+                        {employee.name}
+                      </td>
+                      <td className="border border-[#e1e5ea] px-4 py-4 text-center text-sm text-text-strong">
+                        {/* TODO: 주민등록번호 정보 필요 */}-
+                      </td>
+                      <td className="border border-[#e1e5ea] px-4 py-4 text-center">
+                        {isSigned ? (
+                          <StatusPill variant="success" size="sm">
+                            서명 완료
+                          </StatusPill>
+                        ) : (
+                          <StatusPill variant="danger" size="sm">
+                            서명 대기
+                          </StatusPill>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* 하단 액션 버튼 */}
+      <section className="flex justify-end">
+        <Button variant="primary" size="md" onClick={handleConfirm}>
+          확인
+        </Button>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(manager)/manager/safety-education/create/sign/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/sign/page.tsx
@@ -204,7 +204,11 @@ export default function ManagerSafetyEducationSignPage() {
   const pdfUrl = initialPdfUrl || fetchedPdfUrl;
 
   // 참석자 서명 현황 조회
-  const { data: attendeesData } = useSafetyEducationLogAttendees(parsedSiteId, logId, {
+  const {
+    data: attendeesData,
+    isLoading: isAttendeesLoading,
+    isError: isAttendeesError,
+  } = useSafetyEducationLogAttendees(parsedSiteId, logId, {
     enabled: logId != null && hasValidSiteId,
   });
 
@@ -298,16 +302,32 @@ export default function ManagerSafetyEducationSignPage() {
       return;
     }
 
+    // 참석자 데이터가 로딩 중이면 대기
+    if (isAttendeesLoading) {
+      notification.info({
+        message: "참석자 서명 현황을 불러오는 중입니다. 잠시 후 다시 시도해주세요.",
+        placement: "topRight",
+      });
+      return;
+    }
+
+    // 참석자 데이터가 없거나 에러가 발생한 경우
+    if (!attendeesData || isAttendeesError) {
+      notification.error({
+        message: "참석자 서명 현황을 불러올 수 없습니다. 페이지를 새로고침한 후 다시 시도해주세요.",
+        placement: "topRight",
+      });
+      return;
+    }
+
     // 모든 근로자가 서명 완료되었는지 확인
-    if (attendeesData) {
-      const allSigned = attendeesData.attendees.every((attendee) => attendee.isSigned);
-      if (!allSigned) {
-        notification.warning({
-          message: "모든 교육 대상자의 서명이 완료되어야 합니다.",
-          placement: "topRight",
-        });
-        return;
-      }
+    const allSigned = attendeesData.attendees.every((attendee) => attendee.isSigned);
+    if (!allSigned) {
+      notification.warning({
+        message: "모든 교육 대상자의 서명이 완료되어야 합니다.",
+        placement: "topRight",
+      });
+      return;
     }
 
     // 모든 서명이 완료되었으면 목록 페이지로 이동
@@ -531,7 +551,12 @@ export default function ManagerSafetyEducationSignPage() {
 
       {/* 하단 액션 버튼 */}
       <section className="flex justify-end">
-        <Button variant="primary" size="md" onClick={handleConfirm}>
+        <Button
+          variant="primary"
+          size="md"
+          onClick={handleConfirm}
+          disabled={isAttendeesLoading || !attendeesData}
+        >
           확인
         </Button>
       </section>

--- a/src/app/(manager)/manager/safety-education/create/sign/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/sign/page.tsx
@@ -13,15 +13,11 @@ import { StatusPill } from "@/components/ui/StatusPill/status-pill";
 import { useSiteDetail } from "@/hooks/use-site-detail";
 import { useSessionStore } from "@/stores/session-store";
 import { useQuery } from "@tanstack/react-query";
-import { useCreateSafetyEducationReport } from "@/hooks/use-create-safety-education-report";
-import { handleSafetyEducationManagerSignature } from "@/lib/api/safety-education-signature";
-import { getSafetyEducationReportPdfUrl } from "@/lib/api/get-safety-education-report-pdf";
-
-type SelectedEmployee = {
-  employeeId: number;
-  name: string;
-  employmentType: "REGULAR" | "DAILY";
-};
+import { useCreateSafetyEducationLog } from "@/hooks/use-create-safety-education-log";
+import { handleSafetyEducationLogManagerSignature } from "@/lib/api/safety-education-log-signature";
+import { getSafetyEducationLogPdfUrl } from "@/lib/api/get-safety-education-log-pdf";
+import { useSafetyEducationLogAttendees } from "@/hooks/use-safety-education-log-attendees";
+import { useSafetyEducationLogs } from "@/hooks/use-safety-education-logs";
 
 export default function ManagerSafetyEducationSignPage() {
   const router = useRouter();
@@ -34,101 +30,162 @@ export default function ManagerSafetyEducationSignPage() {
 
   const signaturePadRef = useRef<SignatureCanvas | null>(null);
   const [hasSignature, setHasSignature] = useState(false);
+  // 서명 완료 시점의 로컬 상태 (즉시 반영용)
+  const [isManagerSigned, setIsManagerSigned] = useState(false);
+
+  // 쿼리 파라미터에서 logId 가져오기 (기존 로그를 불러올 때)
+  const logIdFromQuery = useMemo(() => {
+    const logIdParam = searchParams.get("logId");
+    return logIdParam ? Number.parseInt(logIdParam, 10) : null;
+  }, [searchParams]);
+
+  // logId가 있을 때 안전교육일지 목록에서 정보 가져오기
+  const { data: logsData } = useSafetyEducationLogs(
+    {
+      siteId: parsedSiteId,
+    },
+    {
+      enabled: hasValidSiteId && logIdFromQuery != null,
+    },
+  );
+
+  // 목록에서 해당 logId의 항목 찾기
+  const logItem = useMemo(() => {
+    if (!logsData?.items || !logIdFromQuery) return null;
+    return logsData.items.find((item) => item.id === logIdFromQuery);
+  }, [logsData, logIdFromQuery]);
+
+  // logItem의 status가 업데이트되면 로컬 상태 초기화 (refetch 완료 후)
+  useEffect(() => {
+    if (logItem?.status === "MANAGER_SIGNED" || logItem?.status === "COMPLETED") {
+      setIsManagerSigned(false); // API에서 받은 상태로 동기화
+    }
+  }, [logItem?.status]);
 
   // Query params에서 교육 정보 및 선택된 근로자 가져오기
   const educationData = useMemo(() => {
-    const selectedEmployeesJson = searchParams.get("selectedEmployees");
-    let selectedEmployees: SelectedEmployee[] = [];
-    if (selectedEmployeesJson) {
+    const selectedEmployeeIdsJson = searchParams.get("selectedEmployeeIds");
+    let selectedEmployeeIds: number[] = [];
+    if (selectedEmployeeIdsJson) {
       try {
-        selectedEmployees = JSON.parse(selectedEmployeesJson);
+        selectedEmployeeIds = JSON.parse(selectedEmployeeIdsJson);
       } catch (e) {
-        console.error("Failed to parse selectedEmployees", e);
+        console.error("Failed to parse selectedEmployeeIds", e);
       }
     }
 
+    // logId가 있고 목록에서 정보를 찾았으면 그것을 우선 사용
+    if (logItem) {
+      return {
+        siteName: siteDetail?.siteName ?? "",
+        siteAddress: siteDetail?.siteAddress ?? "",
+        educationType: logItem.educationType,
+        educationSubject: logItem.educationSubject,
+        educationContent: "", // 목록 API에는 없음
+        instructorName: logItem.instructorName,
+        educationLocation: "", // 목록 API에는 없음
+        selectedEmployeeIds, // 참석자 정보는 attendees API에서 가져옴
+      };
+    }
+
+    // 그 외에는 쿼리 파라미터에서 가져오기
     return {
       siteName: searchParams.get("siteName") ?? "",
       siteAddress: searchParams.get("siteAddress") ?? "",
-      educationDate: searchParams.get("educationDate") ?? "",
-      author: searchParams.get("author") ?? "",
       educationType: searchParams.get("educationType") ?? "",
-      otherEducationType: searchParams.get("otherEducationType") ?? "",
       educationSubject: searchParams.get("educationSubject") ?? "",
       educationContent: searchParams.get("educationContent") ?? "",
       instructorName: searchParams.get("instructorName") ?? "",
       educationLocation: searchParams.get("educationLocation") ?? "",
-      selectedEmployees,
+      selectedEmployeeIds,
     };
-  }, [searchParams]);
+  }, [searchParams, logItem, siteDetail]);
 
   const signerName = user?.name ?? "";
   const signDate = dayjs().format("YYYY-MM-DD");
 
-  const [reportId, setReportId] = useState<number | null>(null);
+  const [logId, setLogId] = useState<number | null>(logIdFromQuery);
+  const [initialPdfUrl, setInitialPdfUrl] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const hasCreatedRef = useRef(false);
 
-  const createReportMutation = useCreateSafetyEducationReport(parsedSiteId, {
+  // logIdFromQuery가 변경되면 logId 업데이트
+  useEffect(() => {
+    if (logIdFromQuery != null && !Number.isNaN(logIdFromQuery)) {
+      setLogId(logIdFromQuery);
+    }
+  }, [logIdFromQuery]);
+
+  const createLogMutation = useCreateSafetyEducationLog(parsedSiteId, {
     onSuccess: (data) => {
-      setReportId(data.safetyEducationReportId);
+      setLogId(data.safetyEducationLogId);
+      setInitialPdfUrl(data.pdfUrl);
       setIsCreating(false);
       notification.success({
-        message: "안전교육 일지가 생성되었습니다.",
+        message: "안전교육일지가 생성되었습니다.",
         placement: "topRight",
       });
     },
     onError: (error) => {
       setIsCreating(false);
       notification.error({
-        message: error.message || "안전교육 일지를 생성하는 중 오류가 발생했습니다.",
+        message: error.message || "안전교육일지를 생성하는 중 오류가 발생했습니다.",
         placement: "topRight",
       });
     },
   });
 
-  // 페이지 로드 시 안전교육 일지 생성 (한 번만 실행)
+  // 페이지 로드 시 안전교육일지 생성 (logId가 없을 때만, 한 번만 실행)
   useEffect(() => {
     if (
       !hasCreatedRef.current &&
       !isCreating &&
-      !reportId &&
+      !logId &&
       hasValidSiteId &&
-      educationData.selectedEmployees.length > 0 &&
-      !createReportMutation.isPending
+      educationData.selectedEmployeeIds.length > 0 &&
+      !createLogMutation.isPending
     ) {
       hasCreatedRef.current = true;
       setIsCreating(true);
-      createReportMutation.mutate({
-        educationDate: educationData.educationDate,
+      createLogMutation.mutate({
         educationType: educationData.educationType as
           | "REGULAR"
           | "HIRING"
           | "WORK_CHANGE"
           | "SPECIAL"
           | "OTHER",
-        otherEducationType:
-          educationData.educationType === "OTHER" ? educationData.otherEducationType : undefined,
         educationSubject: educationData.educationSubject,
         educationContent: educationData.educationContent,
         instructorName: educationData.instructorName,
         educationLocation: educationData.educationLocation,
-        participants: educationData.selectedEmployees,
+        attendeeEmployeeIds: educationData.selectedEmployeeIds,
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasValidSiteId, educationData.selectedEmployees.length]);
+  }, [hasValidSiteId, educationData.selectedEmployeeIds.length, logId]);
 
-  const { data: pdfUrl, isLoading: isPdfLoading } = useQuery({
-    queryKey: ["safety-education-report-pdf", parsedSiteId, reportId],
+  // 초기 PDF URL이 있으면 사용, 없으면 API에서 가져오기
+  const {
+    data: fetchedPdfUrl,
+    isLoading: isPdfLoading,
+    refetch: refetchPdf,
+  } = useQuery({
+    queryKey: ["safety-education-log-pdf", parsedSiteId, logId],
     queryFn: () => {
-      if (reportId == null) {
-        return Promise.reject(new Error("안전교육 일지 ID가 없습니다."));
+      if (logId == null) {
+        return Promise.reject(new Error("안전교육일지 ID가 없습니다."));
       }
-      return getSafetyEducationReportPdfUrl(parsedSiteId, reportId);
+      return getSafetyEducationLogPdfUrl(parsedSiteId, logId);
     },
-    enabled: reportId != null && hasValidSiteId,
+    enabled: logId != null && hasValidSiteId,
     staleTime: 1000 * 60 * 5,
+  });
+
+  const pdfUrl = initialPdfUrl || fetchedPdfUrl;
+
+  // 참석자 서명 현황 조회
+  const { data: attendeesData } = useSafetyEducationLogAttendees(parsedSiteId, logId, {
+    enabled: logId != null && hasValidSiteId,
   });
 
   useEffect(() => {
@@ -174,9 +231,9 @@ export default function ManagerSafetyEducationSignPage() {
       return;
     }
 
-    if (!reportId) {
+    if (!logId) {
       notification.error({
-        message: "안전교육 일지가 생성되지 않았습니다. 잠시 후 다시 시도해주세요.",
+        message: "안전교육일지가 생성되지 않았습니다. 잠시 후 다시 시도해주세요.",
         placement: "topRight",
       });
       return;
@@ -184,7 +241,16 @@ export default function ManagerSafetyEducationSignPage() {
 
     try {
       const dataUrl = pad.toDataURL("image/png");
-      await handleSafetyEducationManagerSignature(parsedSiteId, reportId, dataUrl);
+      await handleSafetyEducationLogManagerSignature(parsedSiteId, logId, dataUrl);
+
+      // 서명 완료 로컬 상태 업데이트 (즉시 UI 반영)
+      setIsManagerSigned(true);
+
+      // 서명 후 PDF URL을 다시 조회 (서명된 PDF를 가져오기 위해)
+      // initialPdfUrl을 null로 설정하여 API에서 다시 가져오도록 함
+      setInitialPdfUrl(null);
+      // 쿼리 재조회
+      await refetchPdf();
 
       notification.success({
         message: "담당자 서명이 저장되었습니다.",
@@ -204,18 +270,28 @@ export default function ManagerSafetyEducationSignPage() {
   };
 
   const handleConfirm = () => {
-    if (!reportId) {
+    if (!logId) {
       notification.warning({
-        message: "안전교육 일지가 생성되지 않았습니다.",
+        message: "안전교육일지가 생성되지 않았습니다.",
         placement: "topRight",
       });
       return;
     }
-    router.push("/manager/safety-education?created=true");
-  };
 
-  const handlePrint = () => {
-    window.print();
+    // 모든 근로자가 서명 완료되었는지 확인
+    if (attendeesData) {
+      const allSigned = attendeesData.attendees.every((attendee) => attendee.isSigned);
+      if (!allSigned) {
+        notification.warning({
+          message: "모든 교육 대상자의 서명이 완료되어야 합니다.",
+          placement: "topRight",
+        });
+        return;
+      }
+    }
+
+    // 모든 서명이 완료되었으면 목록 페이지로 이동
+    router.push("/manager/safety-education?created=true");
   };
 
   const handleDownloadPdf = () => {
@@ -246,34 +322,13 @@ export default function ManagerSafetyEducationSignPage() {
         </p>
       </header>
 
-      {/* 교육 기본 정보 */}
-      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
-        <div className="grid grid-cols-2 gap-6">
-          <div>
-            <label className="mb-2 block text-sm text-brand-primary-strong">교육 일자</label>
-            <Input
-              value={dayjs(educationData.educationDate).format("YYYY-MM-DD")}
-              disabled
-              className="rounded-lg"
-            />
-          </div>
-          <div>
-            <label className="mb-2 block text-sm text-brand-primary-strong">작성자</label>
-            <Input value={educationData.author} disabled className="rounded-lg" />
-          </div>
-        </div>
-      </section>
-
       {/* 문서 미리보기 */}
       <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
         <div className="mb-4 flex items-center justify-between">
           <h3 className="mb-0 text-lg font-normal text-brand-primary-strong">문서 미리보기</h3>
           <div className="flex gap-2">
-            <Button variant="secondary" size="md" onClick={handlePrint}>
-              인쇄
-            </Button>
             <Button variant="primary" size="md" onClick={handleDownloadPdf}>
-              PDF 다운로드
+              새 창 열기
             </Button>
           </div>
         </div>
@@ -320,56 +375,62 @@ export default function ManagerSafetyEducationSignPage() {
         </div>
       </section>
 
-      {/* 담당자 서명 */}
-      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
-        <h3 className="mb-4 text-lg font-normal text-brand-primary-strong">담당자 서명</h3>
-        <div className="grid grid-cols-2 gap-6">
-          <div className="space-y-4">
-            <div>
-              <label className="mb-2 block text-sm text-brand-primary-strong">서명자 이름</label>
-              <Input value={signerName} disabled className="rounded-lg" />
-            </div>
-            <div>
-              <label className="mb-2 block text-sm text-brand-primary-strong">서명일자</label>
-              <Input value={signDate} disabled className="rounded-lg" />
-            </div>
-          </div>
-          <div>
-            <label className="mb-2 block text-sm text-brand-primary-strong">서명 입력란</label>
-            <div className="relative rounded-xl border border-[#d1d5db] bg-[#f9fafb] p-4">
-              <SignatureCanvas
-                ref={signaturePadRef}
-                canvasProps={{
-                  className: "w-full h-48 border-0 bg-transparent",
-                }}
-                onEnd={() => setHasSignature(true)}
-              />
-              <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-                {!hasSignature && (
-                  <div className="text-center text-text-subtle">
-                    <Image
-                      src="/assets/icons/signature.svg"
-                      alt="서명"
-                      width={30}
-                      height={30}
-                      className="mx-auto mb-2 opacity-30"
-                    />
-                    <p className="text-sm italic">여기에 서명하세요</p>
+      {/* 담당자 서명 - 관리자 서명이 완료되지 않은 경우에만 표시 */}
+      {!isManagerSigned &&
+        logItem?.status !== "MANAGER_SIGNED" &&
+        logItem?.status !== "COMPLETED" && (
+          <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+            <h3 className="mb-4 text-lg font-normal text-brand-primary-strong">담당자 서명</h3>
+            <div className="grid grid-cols-2 gap-6">
+              <div className="space-y-4">
+                <div>
+                  <label className="mb-2 block text-sm text-brand-primary-strong">
+                    서명자 이름
+                  </label>
+                  <Input value={signerName} disabled className="rounded-lg" />
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm text-brand-primary-strong">서명일자</label>
+                  <Input value={signDate} disabled className="rounded-lg" />
+                </div>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm text-brand-primary-strong">서명 입력란</label>
+                <div className="relative rounded-xl border border-[#d1d5db] bg-[#f9fafb] p-4">
+                  <SignatureCanvas
+                    ref={signaturePadRef}
+                    canvasProps={{
+                      className: "w-full h-48 border-0 bg-transparent",
+                    }}
+                    onEnd={() => setHasSignature(true)}
+                  />
+                  <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                    {!hasSignature && (
+                      <div className="text-center text-text-subtle">
+                        <Image
+                          src="/assets/icons/signature.svg"
+                          alt="서명"
+                          width={30}
+                          height={30}
+                          className="mx-auto mb-2 opacity-30"
+                        />
+                        <p className="text-sm italic">여기에 서명하세요</p>
+                      </div>
+                    )}
                   </div>
-                )}
+                </div>
+                <div className="mt-2 flex gap-2">
+                  <Button variant="secondary" size="md" onClick={handleSignatureClear}>
+                    서명 지우기
+                  </Button>
+                  <Button variant="primary" size="md" onClick={handleSignatureSave}>
+                    서명 저장하기
+                  </Button>
+                </div>
               </div>
             </div>
-            <div className="mt-2 flex gap-2">
-              <Button variant="secondary" size="md" onClick={handleSignatureClear}>
-                서명 지우기
-              </Button>
-              <Button variant="primary" size="md" onClick={handleSignatureSave}>
-                서명 저장하기
-              </Button>
-            </div>
-          </div>
-        </div>
-      </section>
+          </section>
+        )}
 
       {/* 교육 대상자 서명 현황 */}
       <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
@@ -395,7 +456,16 @@ export default function ManagerSafetyEducationSignPage() {
               </tr>
             </thead>
             <tbody>
-              {educationData.selectedEmployees.length === 0 ? (
+              {!attendeesData ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="border border-[#e1e5ea] px-4 py-8 text-center text-text-subtle"
+                  >
+                    참석자 정보를 불러오는 중...
+                  </td>
+                </tr>
+              ) : attendeesData.attendees.length === 0 ? (
                 <tr>
                   <td
                     colSpan={4}
@@ -405,23 +475,20 @@ export default function ManagerSafetyEducationSignPage() {
                   </td>
                 </tr>
               ) : (
-                educationData.selectedEmployees.map((employee, index) => {
-                  // TODO: 실제 서명 상태는 API에서 받아와야 함
-                  const isSigned = index % 2 === 0; // 임시로 일부만 서명 완료로 표시
-
+                attendeesData.attendees.map((attendee) => {
                   return (
-                    <tr key={employee.employeeId}>
+                    <tr key={attendee.employeeId}>
                       <td className="border border-[#e1e5ea] px-4 py-4 text-center text-sm text-text-strong">
-                        {employee.employmentType === "REGULAR" ? "상용" : "일용"}
+                        {attendee.empType === "PERMANENT" ? "상용" : "일용"}
                       </td>
                       <td className="border border-[#e1e5ea] px-4 py-4 text-center text-sm text-text-strong">
-                        {employee.name}
+                        {attendee.empName}
                       </td>
                       <td className="border border-[#e1e5ea] px-4 py-4 text-center text-sm text-text-strong">
-                        {/* TODO: 주민등록번호 정보 필요 */}-
+                        {/* 주민등록번호는 API에서 제공되지 않음 */}-
                       </td>
                       <td className="border border-[#e1e5ea] px-4 py-4 text-center">
-                        {isSigned ? (
+                        {attendee.isSigned ? (
                           <StatusPill variant="success" size="sm">
                             서명 완료
                           </StatusPill>

--- a/src/app/(manager)/manager/safety-education/create/sign/page.tsx
+++ b/src/app/(manager)/manager/safety-education/create/sign/page.tsx
@@ -62,18 +62,8 @@ export default function ManagerSafetyEducationSignPage() {
     }
   }, [logItem?.status]);
 
-  // Query params에서 교육 정보 및 선택된 근로자 가져오기
+  // 세션 스토리지에서 교육 정보 및 선택된 근로자 가져오기 (긴 텍스트를 URL에 포함하지 않기 위해)
   const educationData = useMemo(() => {
-    const selectedEmployeeIdsJson = searchParams.get("selectedEmployeeIds");
-    let selectedEmployeeIds: number[] = [];
-    if (selectedEmployeeIdsJson) {
-      try {
-        selectedEmployeeIds = JSON.parse(selectedEmployeeIdsJson);
-      } catch (e) {
-        console.error("Failed to parse selectedEmployeeIds", e);
-      }
-    }
-
     // logId가 있고 목록에서 정보를 찾았으면 그것을 우선 사용
     if (logItem) {
       return {
@@ -84,11 +74,41 @@ export default function ManagerSafetyEducationSignPage() {
         educationContent: "", // 목록 API에는 없음
         instructorName: logItem.instructorName,
         educationLocation: "", // 목록 API에는 없음
-        selectedEmployeeIds, // 참석자 정보는 attendees API에서 가져옴
+        selectedEmployeeIds: [], // 참석자 정보는 attendees API에서 가져옴
       };
     }
 
-    // 그 외에는 쿼리 파라미터에서 가져오기
+    // 세션 스토리지에서 가져오기
+    const storedData = sessionStorage.getItem("safety-education-form-data");
+    if (storedData) {
+      try {
+        const parsed = JSON.parse(storedData);
+        return {
+          siteName: parsed.siteName ?? "",
+          siteAddress: parsed.siteAddress ?? "",
+          educationType: parsed.educationType ?? "",
+          educationSubject: parsed.educationSubject ?? "",
+          educationContent: parsed.educationContent ?? "",
+          instructorName: parsed.instructorName ?? "",
+          educationLocation: parsed.educationLocation ?? "",
+          selectedEmployeeIds: parsed.selectedEmployeeIds ?? [],
+        };
+      } catch (e) {
+        console.error("Failed to parse education data from sessionStorage", e);
+      }
+    }
+
+    // 폴백: 쿼리 파라미터에서 가져오기 (하위 호환성)
+    const selectedEmployeeIdsJson = searchParams.get("selectedEmployeeIds");
+    let selectedEmployeeIds: number[] = [];
+    if (selectedEmployeeIdsJson) {
+      try {
+        selectedEmployeeIds = JSON.parse(selectedEmployeeIdsJson);
+      } catch (e) {
+        console.error("Failed to parse selectedEmployeeIds", e);
+      }
+    }
+
     return {
       siteName: searchParams.get("siteName") ?? "",
       siteAddress: searchParams.get("siteAddress") ?? "",
@@ -291,6 +311,8 @@ export default function ManagerSafetyEducationSignPage() {
     }
 
     // 모든 서명이 완료되었으면 목록 페이지로 이동
+    // 세션 스토리지 정리
+    sessionStorage.removeItem("safety-education-form-data");
     router.push("/manager/safety-education?created=true");
   };
 

--- a/src/app/(manager)/manager/safety-education/page.tsx
+++ b/src/app/(manager)/manager/safety-education/page.tsx
@@ -7,11 +7,11 @@ import { useQuery } from "@tanstack/react-query";
 import { ManagerSafetyEducationTable } from "@/components/features/manager/safety-education/manager-safety-education-table";
 import { Button } from "@/components/ui/Button/button";
 import { PDFViewer } from "@/components/common/pdf-viewer";
-import { useSafetyEducationReports } from "@/hooks/use-safety-education-reports";
+import { useSafetyEducationLogs } from "@/hooks/use-safety-education-logs";
 import { useSiteDetail } from "@/hooks/use-site-detail";
 import { useSessionStore } from "@/stores/session-store";
-import { getSafetyEducationReportPdfUrl } from "@/lib/api/get-safety-education-report-pdf";
-import type { ManagerSafetyEducationReportRow } from "@/components/features/manager/safety-education/manager-safety-education-table";
+import { getSafetyEducationLogPdfUrl } from "@/lib/api/get-safety-education-log-pdf";
+import type { ManagerSafetyEducationLogRow } from "@/components/features/manager/safety-education/manager-safety-education-table";
 
 export default function ManagerSafetyEducationPage() {
   const router = useRouter();
@@ -22,50 +22,45 @@ export default function ManagerSafetyEducationPage() {
 
   const { data: siteDetail } = useSiteDetail(parsedSiteId);
 
-  const [page, setPage] = useState(1);
-  const pageSize = 20;
-
   const {
-    data: reportsData,
+    data: logsData,
     isLoading,
     isFetching,
     isError,
     error,
     refetch,
-  } = useSafetyEducationReports(
+  } = useSafetyEducationLogs(
     {
       siteId: parsedSiteId,
-      page,
-      size: pageSize,
     },
     {
       enabled: hasValidSiteId,
     },
   );
 
-  const records: ManagerSafetyEducationReportRow[] =
-    reportsData?.items?.map((item) => ({
-      id: item.safetyEducationReportId,
-      educationDate: item.educationDate,
-      writerName: item.writerName,
-      participantCount: item.participantCount,
+  const records: ManagerSafetyEducationLogRow[] =
+    logsData?.items?.map((item) => ({
+      id: item.id,
+      createdAt: item.createdAt,
+      instructorName: item.instructorName,
+      totalAttendeeCount: item.totalAttendeeCount,
+      signedAttendeeCount: item.signedAttendeeCount,
       status: item.status,
     })) ?? [];
-  const totalCount = reportsData?.pagination.totalElements ?? 0;
   const tableLoading = isLoading || isFetching;
 
-  const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
+  const [selectedLogId, setSelectedLogId] = useState<number | null>(null);
 
-  // 안전교육 일지 PDF URL 가져오기
-  const { data: reportPdfUrl, isLoading: isPdfLoading } = useQuery({
-    queryKey: ["safety-education-report-pdf", parsedSiteId, selectedReportId],
+  // 안전교육일지 PDF URL 가져오기
+  const { data: logPdfUrl, isLoading: isPdfLoading } = useQuery({
+    queryKey: ["safety-education-log-pdf", parsedSiteId, selectedLogId],
     queryFn: () => {
-      if (selectedReportId == null) {
-        return Promise.reject(new Error("안전교육 일지 ID가 없습니다."));
+      if (selectedLogId == null) {
+        return Promise.reject(new Error("안전교육일지 ID가 없습니다."));
       }
-      return getSafetyEducationReportPdfUrl(parsedSiteId, selectedReportId);
+      return getSafetyEducationLogPdfUrl(parsedSiteId, selectedLogId);
     },
-    enabled: selectedReportId != null && hasValidSiteId,
+    enabled: selectedLogId != null && hasValidSiteId,
     staleTime: 1000 * 60 * 5, // 5분
   });
 
@@ -111,21 +106,32 @@ export default function ManagerSafetyEducationPage() {
     router.push("/manager/safety-education/create");
   };
 
-  const handleViewDetail = (reportId: number) => {
-    setSelectedReportId(reportId);
+  const handleViewDetail = (logId: number, status: ManagerSafetyEducationLogRow["status"]) => {
+    // 관리자 서명 대기 또는 관리자 서명 완료 상태인 경우 서명 페이지로 이동
+    if (status === "MANAGER_SIGNING_PENDING" || status === "MANAGER_SIGNED") {
+      router.push(`/manager/safety-education/create/sign?logId=${logId}`);
+      return;
+    }
+    // 완료 상태(모든 서명 완료)인 경우에만 PDF 모달 열기
+    if (status === "COMPLETED") {
+      setSelectedLogId(logId);
+      return;
+    }
+    // 그 외 상태도 PDF 모달 열기 (안전장치)
+    setSelectedLogId(logId);
   };
 
   const handleCloseModal = () => {
-    setSelectedReportId(null);
+    setSelectedLogId(null);
   };
 
   const handleOpenInNewWindow = () => {
-    if (reportPdfUrl) {
-      window.open(reportPdfUrl, "_blank");
+    if (logPdfUrl) {
+      window.open(logPdfUrl, "_blank");
     }
   };
 
-  const selectedReport = records.find((r) => r.id === selectedReportId);
+  const selectedLog = records.find((r) => r.id === selectedLogId);
 
   const disabledMessage = !hasValidSiteId
     ? "현장 정보가 없어 안전교육 일지 데이터를 불러올 수 없습니다. 관리자에게 현장 정보 설정을 요청해주세요."
@@ -173,17 +179,13 @@ export default function ManagerSafetyEducationPage() {
           <ManagerSafetyEducationTable
             records={records}
             isLoading={tableLoading}
-            currentPage={page}
-            pageSize={pageSize}
-            total={totalCount}
-            onPageChange={(newPage) => setPage(newPage)}
             onViewDetail={handleViewDetail}
           />
         )}
       </section>
 
       <Modal
-        open={selectedReportId !== null}
+        open={selectedLogId !== null}
         onCancel={handleCloseModal}
         footer={null}
         centered
@@ -196,16 +198,14 @@ export default function ManagerSafetyEducationPage() {
         <div className="flex flex-col gap-4">
           <div className="flex items-start justify-between">
             <div>
-              <p className="mb-0! text-2xl font-semibold text-brand-primary-strong">
-                안전교육 일지
-              </p>
+              <p className="mb-0! text-2xl font-semibold text-brand-primary-strong">안전교육일지</p>
               <p className="mb-0! text-sm text-text-subtle">
                 {siteDetail?.siteName ?? ""}
-                {selectedReport ? ` | ${selectedReport.educationDate}` : ""}
+                {selectedLog ? ` | ${new Date(selectedLog.createdAt).toLocaleDateString()}` : ""}
               </p>
             </div>
             <div className="flex items-center gap-2 mr-4">
-              {reportPdfUrl && (
+              {logPdfUrl && (
                 <Button variant="primary" size="md" onClick={handleOpenInNewWindow}>
                   전체 보기
                 </Button>
@@ -217,8 +217,8 @@ export default function ManagerSafetyEducationPage() {
               <div className="flex h-[480px] items-center justify-center text-text-subtle">
                 PDF를 불러오는 중...
               </div>
-            ) : reportPdfUrl ? (
-              <PDFViewer pdfUrl={reportPdfUrl} />
+            ) : logPdfUrl ? (
+              <PDFViewer pdfUrl={logPdfUrl} />
             ) : (
               <div className="flex h-[480px] items-center justify-center text-text-subtle">
                 PDF를 불러올 수 없습니다.

--- a/src/app/(manager)/manager/safety-education/page.tsx
+++ b/src/app/(manager)/manager/safety-education/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Modal, notification } from "antd";
+import { useQuery } from "@tanstack/react-query";
+import { ManagerSafetyEducationTable } from "@/components/features/manager/safety-education/manager-safety-education-table";
+import { Button } from "@/components/ui/Button/button";
+import { PDFViewer } from "@/components/common/pdf-viewer";
+import { useSafetyEducationReports } from "@/hooks/use-safety-education-reports";
+import { useSiteDetail } from "@/hooks/use-site-detail";
+import { useSessionStore } from "@/stores/session-store";
+import { getSafetyEducationReportPdfUrl } from "@/lib/api/get-safety-education-report-pdf";
+import type { ManagerSafetyEducationReportRow } from "@/components/features/manager/safety-education/manager-safety-education-table";
+
+export default function ManagerSafetyEducationPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const user = useSessionStore((state) => state.user);
+  const parsedSiteId = user?.siteId ?? 0;
+  const hasValidSiteId = !!parsedSiteId && !Number.isNaN(parsedSiteId);
+
+  const { data: siteDetail } = useSiteDetail(parsedSiteId);
+
+  const [page, setPage] = useState(1);
+  const pageSize = 20;
+
+  const {
+    data: reportsData,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useSafetyEducationReports(
+    {
+      siteId: parsedSiteId,
+      page,
+      size: pageSize,
+    },
+    {
+      enabled: hasValidSiteId,
+    },
+  );
+
+  const records: ManagerSafetyEducationReportRow[] =
+    reportsData?.items?.map((item) => ({
+      id: item.safetyEducationReportId,
+      educationDate: item.educationDate,
+      writerName: item.writerName,
+      participantCount: item.participantCount,
+      status: item.status,
+    })) ?? [];
+  const totalCount = reportsData?.pagination.totalElements ?? 0;
+  const tableLoading = isLoading || isFetching;
+
+  const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
+
+  // 안전교육 일지 PDF URL 가져오기
+  const { data: reportPdfUrl, isLoading: isPdfLoading } = useQuery({
+    queryKey: ["safety-education-report-pdf", parsedSiteId, selectedReportId],
+    queryFn: () => {
+      if (selectedReportId == null) {
+        return Promise.reject(new Error("안전교육 일지 ID가 없습니다."));
+      }
+      return getSafetyEducationReportPdfUrl(parsedSiteId, selectedReportId);
+    },
+    enabled: selectedReportId != null && hasValidSiteId,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+
+  const lastErrorMessageRef = useRef<string | null>(null);
+
+  // 작성 완료 후 돌아온 경우 목록 새로고침
+  useEffect(() => {
+    const created = searchParams.get("created");
+    if (created === "true") {
+      refetch();
+      // 쿼리스트링 정리
+      const cleaned = new URLSearchParams(Array.from(searchParams.entries()));
+      cleaned.delete("created");
+      const queryString = cleaned.toString();
+      router.replace(
+        queryString ? `/manager/safety-education?${queryString}` : "/manager/safety-education",
+      );
+    }
+  }, [searchParams, router, refetch]);
+
+  useEffect(() => {
+    if (!isError && !error) {
+      lastErrorMessageRef.current = null;
+      return;
+    }
+    if (!isError || !error) {
+      return;
+    }
+    const message =
+      error instanceof Error
+        ? error.message
+        : "안전교육 일지 데이터를 불러오는 중 오류가 발생했습니다.";
+    if (lastErrorMessageRef.current === message) return;
+    lastErrorMessageRef.current = message;
+    notification.error({
+      message,
+      placement: "topRight",
+      duration: 3,
+    });
+  }, [isError, error]);
+
+  const handleCreate = () => {
+    router.push("/manager/safety-education/create");
+  };
+
+  const handleViewDetail = (reportId: number) => {
+    setSelectedReportId(reportId);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedReportId(null);
+  };
+
+  const handleOpenInNewWindow = () => {
+    if (reportPdfUrl) {
+      window.open(reportPdfUrl, "_blank");
+    }
+  };
+
+  const selectedReport = records.find((r) => r.id === selectedReportId);
+
+  const disabledMessage = !hasValidSiteId
+    ? "현장 정보가 없어 안전교육 일지 데이터를 불러올 수 없습니다. 관리자에게 현장 정보 설정을 요청해주세요."
+    : undefined;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-lg border border-border bg-bg-surface p-3 dark:border-dark-border dark:bg-dark-bg-surface">
+        <header className="space-y-1">
+          <h1 className="mb-0! text-2xl font-semibold! text-text-strong dark:text-dark-text-strong">
+            {siteDetail?.siteName ?? "현장 이름을 불러오는 중..."}
+          </h1>
+          <p className="mb-0! text-base text-text-subtle dark:text-dark-text-base">
+            {siteDetail?.siteAddress ?? "현장 주소를 불러오는 중입니다."}
+          </p>
+        </header>
+      </section>
+
+      <header className="ml-3 space-y-1">
+        <h2 className="mb-0! text-2xl font-semibold! text-brand-primary-strong dark:text-dark-text-strong">
+          안전교육일지 작성
+        </h2>
+        <p className="mb-0! text-sm text-text-subtle dark:text-dark-text-base">
+          진행한 안전교육에 대해 일지를 작성합니다.
+        </p>
+      </header>
+
+      <section className="rounded-2xl border border-border bg-bg-surface px-6 py-4 dark:border-dark-border dark:bg-dark-bg-surface">
+        <div className="flex items-center justify-between">
+          <h3 className="mb-0 text-xl font-semibold text-brand-primary-strong">
+            안전교육 일지 목록
+          </h3>
+          <Button variant="primary" size="md" onClick={handleCreate}>
+            작성하기
+          </Button>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-border bg-bg-surface p-6 dark:border-dark-border dark:bg-dark-bg-surface">
+        {!hasValidSiteId ? (
+          <div className="flex h-40 items-center justify-center text-sm text-text-subtle dark:text-dark-text-base">
+            {disabledMessage}
+          </div>
+        ) : (
+          <ManagerSafetyEducationTable
+            records={records}
+            isLoading={tableLoading}
+            currentPage={page}
+            pageSize={pageSize}
+            total={totalCount}
+            onPageChange={(newPage) => setPage(newPage)}
+            onViewDetail={handleViewDetail}
+          />
+        )}
+      </section>
+
+      <Modal
+        open={selectedReportId !== null}
+        onCancel={handleCloseModal}
+        footer={null}
+        centered
+        width={900}
+        classNames={{
+          content: "bg-white dark:bg-dark-bg-surface",
+          body: "p-6",
+        }}
+      >
+        <div className="flex flex-col gap-4">
+          <div className="flex items-start justify-between">
+            <div>
+              <p className="mb-0! text-2xl font-semibold text-brand-primary-strong">
+                안전교육 일지
+              </p>
+              <p className="mb-0! text-sm text-text-subtle">
+                {siteDetail?.siteName ?? ""}
+                {selectedReport ? ` | ${selectedReport.educationDate}` : ""}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 mr-4">
+              {reportPdfUrl && (
+                <Button variant="primary" size="md" onClick={handleOpenInNewWindow}>
+                  전체 보기
+                </Button>
+              )}
+            </div>
+          </div>
+          <div className="rounded-2xl border border-border bg-bg-subtle p-4">
+            {isPdfLoading ? (
+              <div className="flex h-[480px] items-center justify-center text-text-subtle">
+                PDF를 불러오는 중...
+              </div>
+            ) : reportPdfUrl ? (
+              <PDFViewer pdfUrl={reportPdfUrl} />
+            ) : (
+              <div className="flex h-[480px] items-center justify-center text-text-subtle">
+                PDF를 불러올 수 없습니다.
+              </div>
+            )}
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/components/common/pdf-viewer.tsx
+++ b/src/components/common/pdf-viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/Button/button";
 
@@ -11,6 +11,73 @@ type PDFViewerProps = {
 export function PDFViewer({ pdfUrl }: PDFViewerProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    if (!pdfUrl) {
+      setIsLoading(false);
+      setHasError(true);
+      return;
+    }
+
+    let currentBlobUrl: string | null = null;
+    let isCancelled = false;
+
+    // S3 presigned URL을 blob으로 다운로드하여 CORS 문제 우회
+    const fetchPdfAsBlob = async () => {
+      try {
+        setIsLoading(true);
+        setHasError(false);
+
+        const response = await fetch(pdfUrl, {
+          method: "GET",
+          credentials: "include",
+        });
+
+        if (!response.ok) {
+          throw new Error(`PDF 다운로드 실패: ${response.status}`);
+        }
+
+        const blob = await response.blob();
+
+        // 취소되었으면 blob URL 생성하지 않음
+        if (isCancelled) {
+          return;
+        }
+
+        const url = URL.createObjectURL(blob);
+        currentBlobUrl = url;
+        setBlobUrl(url);
+        setIsLoading(false);
+      } catch (error) {
+        if (!isCancelled) {
+          console.error("PDF 로드 오류:", error);
+          setIsLoading(false);
+          setHasError(true);
+        }
+      }
+    };
+
+    fetchPdfAsBlob();
+
+    // Cleanup: 컴포넌트 언마운트 또는 pdfUrl/retryKey 변경 시 blob URL 해제
+    return () => {
+      isCancelled = true;
+      if (currentBlobUrl) {
+        URL.revokeObjectURL(currentBlobUrl);
+      }
+    };
+  }, [pdfUrl, retryKey]);
+
+  // blobUrl이 변경될 때 이전 blob URL 정리
+  useEffect(() => {
+    return () => {
+      if (blobUrl) {
+        URL.revokeObjectURL(blobUrl);
+      }
+    };
+  }, [blobUrl]);
 
   const handleIframeLoad = () => {
     setIsLoading(false);
@@ -19,6 +86,17 @@ export function PDFViewer({ pdfUrl }: PDFViewerProps) {
   const handleIframeError = () => {
     setIsLoading(false);
     setHasError(true);
+  };
+
+  const handleRetry = () => {
+    setHasError(false);
+    setIsLoading(true);
+    if (blobUrl) {
+      URL.revokeObjectURL(blobUrl);
+      setBlobUrl(null);
+    }
+    // retryKey를 변경하여 useEffect 재실행
+    setRetryKey((prev) => prev + 1);
   };
 
   return (
@@ -39,27 +117,20 @@ export function PDFViewer({ pdfUrl }: PDFViewerProps) {
               <Button variant="primary" size="sm" onClick={() => window.open(pdfUrl, "_blank")}>
                 새 창에서 열기
               </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setHasError(false);
-                  setIsLoading(true);
-                }}
-              >
+              <Button variant="ghost" size="sm" onClick={handleRetry}>
                 다시 시도
               </Button>
             </div>
           </div>
-        ) : (
+        ) : blobUrl ? (
           <iframe
-            src={`${pdfUrl}#toolbar=1&navpanes=1&scrollbar=1`}
+            src={`${blobUrl}#toolbar=1&navpanes=1&scrollbar=1`}
             className="w-full h-[600px] border-0"
             title="PDF Viewer"
             onLoad={handleIframeLoad}
             onError={handleIframeError}
           />
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/features/manager/safety-education/manager-safety-education-table.tsx
+++ b/src/components/features/manager/safety-education/manager-safety-education-table.tsx
@@ -4,22 +4,19 @@ import { Table } from "@/components/ui/Table/table";
 import { StatusPill } from "@/components/ui/StatusPill/status-pill";
 import { cn } from "@/utils/cn";
 
-export type ManagerSafetyEducationReportRow = {
+export type ManagerSafetyEducationLogRow = {
   id: number;
-  educationDate: string;
-  writerName: string;
-  participantCount: number;
-  status: "PENDING" | "IN_PROGRESS" | "COMPLETED";
+  createdAt: string;
+  instructorName: string;
+  totalAttendeeCount: number;
+  signedAttendeeCount: number;
+  status: "DRAFT" | "MANAGER_SIGNING_PENDING" | "MANAGER_SIGNED" | "COMPLETED";
 };
 
 type ManagerSafetyEducationTableProps = {
-  records: ManagerSafetyEducationReportRow[];
+  records: ManagerSafetyEducationLogRow[];
   isLoading: boolean;
-  currentPage: number;
-  pageSize: number;
-  total?: number;
-  onPageChange: (page: number) => void;
-  onViewDetail: (reportId: number) => void;
+  onViewDetail: (logId: number, status: ManagerSafetyEducationLogRow["status"]) => void;
 };
 
 const buttonClass = (enabled: boolean) =>
@@ -31,28 +28,32 @@ const buttonClass = (enabled: boolean) =>
   );
 
 const mapStatusToVariant = (
-  status: ManagerSafetyEducationReportRow["status"],
+  status: ManagerSafetyEducationLogRow["status"],
 ): "success" | "danger" | "warning" | "info" | "neutral" => {
   switch (status) {
     case "COMPLETED":
       return "success";
-    case "PENDING":
-      return "danger";
-    case "IN_PROGRESS":
+    case "DRAFT":
+      return "neutral";
+    case "MANAGER_SIGNING_PENDING":
+      return "warning";
+    case "MANAGER_SIGNED":
       return "info";
     default:
       return "neutral";
   }
 };
 
-const mapStatusToLabel = (status: ManagerSafetyEducationReportRow["status"]): string => {
+const mapStatusToLabel = (status: ManagerSafetyEducationLogRow["status"]): string => {
   switch (status) {
     case "COMPLETED":
       return "완료";
-    case "PENDING":
-      return "서명 대기";
-    case "IN_PROGRESS":
-      return "진행 중";
+    case "DRAFT":
+      return "초안";
+    case "MANAGER_SIGNING_PENDING":
+      return "관리자 서명 대기";
+    case "MANAGER_SIGNED":
+      return "관리자 서명 완료";
     default:
       return status;
   }
@@ -61,38 +62,42 @@ const mapStatusToLabel = (status: ManagerSafetyEducationReportRow["status"]): st
 export function ManagerSafetyEducationTable({
   records,
   isLoading,
-  currentPage,
-  pageSize,
-  total,
-  onPageChange,
   onViewDetail,
 }: ManagerSafetyEducationTableProps) {
-  const columns: ColumnsType<ManagerSafetyEducationReportRow> = [
+  const columns: ColumnsType<ManagerSafetyEducationLogRow> = [
     {
-      title: "작업일자",
-      dataIndex: "educationDate",
-      key: "educationDate",
+      title: "생성일시",
+      dataIndex: "createdAt",
+      key: "createdAt",
+      align: "center",
+      render: (date: string) => new Date(date).toLocaleDateString("ko-KR"),
+    },
+    {
+      title: "교육 실시자",
+      dataIndex: "instructorName",
+      key: "instructorName",
       align: "center",
     },
     {
-      title: "작성자",
-      dataIndex: "writerName",
-      key: "writerName",
+      title: "전체 참석자 수",
+      dataIndex: "totalAttendeeCount",
+      key: "totalAttendeeCount",
       align: "center",
+      render: (count: number) => `${count}명`,
     },
     {
-      title: "교육 대상자 수",
-      dataIndex: "participantCount",
-      key: "participantCount",
+      title: "서명 완료 인원 수",
+      dataIndex: "signedAttendeeCount",
+      key: "signedAttendeeCount",
       align: "center",
-      render: (count) => `${count}명`,
+      render: (count: number) => `${count}명`,
     },
     {
       title: "상태",
       dataIndex: "status",
       key: "status",
       align: "center",
-      render: (status: ManagerSafetyEducationReportRow["status"]) => {
+      render: (status: ManagerSafetyEducationLogRow["status"]) => {
         return (
           <StatusPill variant={mapStatusToVariant(status)} size="sm">
             {mapStatusToLabel(status)}
@@ -109,7 +114,7 @@ export function ManagerSafetyEducationTable({
           <button
             type="button"
             onClick={() => {
-              onViewDetail(record.id);
+              onViewDetail(record.id, record.status);
             }}
             className={buttonClass(true)}
           >
@@ -121,19 +126,12 @@ export function ManagerSafetyEducationTable({
   ];
 
   return (
-    <Table<ManagerSafetyEducationReportRow>
+    <Table<ManagerSafetyEducationLogRow>
       columns={columns}
       dataSource={records}
       rowKey={(record) => record.id}
       loading={isLoading}
-      pagination={{
-        current: currentPage,
-        pageSize,
-        total,
-        onChange: onPageChange,
-        position: ["bottomCenter"],
-        showSizeChanger: false,
-      }}
+      pagination={false}
       showHeaderBar={false}
       borderedContainer={false}
       className="rounded-2xl border border-border bg-white dark:border-dark-border dark:bg-dark-bg-surface"

--- a/src/components/features/manager/safety-education/manager-safety-education-table.tsx
+++ b/src/components/features/manager/safety-education/manager-safety-education-table.tsx
@@ -1,0 +1,142 @@
+import type { ColumnsType } from "antd/es/table";
+
+import { Table } from "@/components/ui/Table/table";
+import { StatusPill } from "@/components/ui/StatusPill/status-pill";
+import { cn } from "@/utils/cn";
+
+export type ManagerSafetyEducationReportRow = {
+  id: number;
+  educationDate: string;
+  writerName: string;
+  participantCount: number;
+  status: "PENDING" | "IN_PROGRESS" | "COMPLETED";
+};
+
+type ManagerSafetyEducationTableProps = {
+  records: ManagerSafetyEducationReportRow[];
+  isLoading: boolean;
+  currentPage: number;
+  pageSize: number;
+  total?: number;
+  onPageChange: (page: number) => void;
+  onViewDetail: (reportId: number) => void;
+};
+
+const buttonClass = (enabled: boolean) =>
+  cn(
+    "inline-flex h-[30px] min-w-[54px] items-center justify-center rounded-lg border px-3 text-sm font-normal transition",
+    enabled
+      ? "border-brand-primary text-brand-primary hover:bg-brand-primary/5"
+      : "cursor-not-allowed border-border text-text-disabled",
+  );
+
+const mapStatusToVariant = (
+  status: ManagerSafetyEducationReportRow["status"],
+): "success" | "danger" | "warning" | "info" | "neutral" => {
+  switch (status) {
+    case "COMPLETED":
+      return "success";
+    case "PENDING":
+      return "danger";
+    case "IN_PROGRESS":
+      return "info";
+    default:
+      return "neutral";
+  }
+};
+
+const mapStatusToLabel = (status: ManagerSafetyEducationReportRow["status"]): string => {
+  switch (status) {
+    case "COMPLETED":
+      return "완료";
+    case "PENDING":
+      return "서명 대기";
+    case "IN_PROGRESS":
+      return "진행 중";
+    default:
+      return status;
+  }
+};
+
+export function ManagerSafetyEducationTable({
+  records,
+  isLoading,
+  currentPage,
+  pageSize,
+  total,
+  onPageChange,
+  onViewDetail,
+}: ManagerSafetyEducationTableProps) {
+  const columns: ColumnsType<ManagerSafetyEducationReportRow> = [
+    {
+      title: "작업일자",
+      dataIndex: "educationDate",
+      key: "educationDate",
+      align: "center",
+    },
+    {
+      title: "작성자",
+      dataIndex: "writerName",
+      key: "writerName",
+      align: "center",
+    },
+    {
+      title: "교육 대상자 수",
+      dataIndex: "participantCount",
+      key: "participantCount",
+      align: "center",
+      render: (count) => `${count}명`,
+    },
+    {
+      title: "상태",
+      dataIndex: "status",
+      key: "status",
+      align: "center",
+      render: (status: ManagerSafetyEducationReportRow["status"]) => {
+        return (
+          <StatusPill variant={mapStatusToVariant(status)} size="sm">
+            {mapStatusToLabel(status)}
+          </StatusPill>
+        );
+      },
+    },
+    {
+      title: "상세보기",
+      key: "detailAction",
+      align: "center",
+      render: (_, record) => {
+        return (
+          <button
+            type="button"
+            onClick={() => {
+              onViewDetail(record.id);
+            }}
+            className={buttonClass(true)}
+          >
+            보기
+          </button>
+        );
+      },
+    },
+  ];
+
+  return (
+    <Table<ManagerSafetyEducationReportRow>
+      columns={columns}
+      dataSource={records}
+      rowKey={(record) => record.id}
+      loading={isLoading}
+      pagination={{
+        current: currentPage,
+        pageSize,
+        total,
+        onChange: onPageChange,
+        position: ["bottomCenter"],
+        showSizeChanger: false,
+      }}
+      showHeaderBar={false}
+      borderedContainer={false}
+      className="rounded-2xl border border-border bg-white dark:border-dark-border dark:bg-dark-bg-surface"
+    />
+  );
+}

--- a/src/hooks/use-create-safety-education-log.ts
+++ b/src/hooks/use-create-safety-education-log.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createSafetyEducationLog,
+  type CreateSafetyEducationLogPayload,
+} from "@/lib/api/create-safety-education-log";
+
+type UseCreateSafetyEducationLogOptions = {
+  onSuccess?: (data: {
+    safetyEducationLogId: number;
+    status: "MANAGER_SIGNING_PENDING" | "MANAGER_SIGNED" | "COMPLETED";
+    pdfUrl: string;
+    attendeeCount: number;
+  }) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useCreateSafetyEducationLog(
+  siteId: number,
+  options?: UseCreateSafetyEducationLogOptions,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreateSafetyEducationLogPayload) =>
+      createSafetyEducationLog(siteId, payload),
+    onSuccess: (data) => {
+      // 안전교육일지 목록 쿼리 무효화
+      queryClient.invalidateQueries({
+        queryKey: ["safety-education-logs", "list"],
+      });
+      if (data) {
+        options?.onSuccess?.(data);
+      }
+    },
+    onError: (error) => {
+      options?.onError?.(error instanceof Error ? error : new Error(String(error)));
+    },
+  });
+}

--- a/src/hooks/use-create-safety-education-report.ts
+++ b/src/hooks/use-create-safety-education-report.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createSafetyEducationReport,
+  type CreateSafetyEducationReportPayload,
+} from "@/lib/api/create-safety-education-report";
+
+type UseCreateSafetyEducationReportOptions = {
+  onSuccess?: (data: { safetyEducationReportId: number; pdfUrl: string }) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useCreateSafetyEducationReport(
+  siteId: number,
+  options?: UseCreateSafetyEducationReportOptions,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreateSafetyEducationReportPayload) =>
+      createSafetyEducationReport(siteId, payload),
+    onSuccess: (data) => {
+      // 안전교육 일지 목록 쿼리 무효화
+      queryClient.invalidateQueries({
+        queryKey: ["safety-education-reports", "list"],
+      });
+      if (data) {
+        options?.onSuccess?.(data);
+      }
+    },
+    onError: (error) => {
+      options?.onError?.(error instanceof Error ? error : new Error(String(error)));
+    },
+  });
+}

--- a/src/hooks/use-safety-education-log-attendees.ts
+++ b/src/hooks/use-safety-education-log-attendees.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getSafetyEducationLogAttendees,
+  type GetSafetyEducationLogAttendeesResponse,
+} from "@/lib/api/get-safety-education-log-attendees";
+
+type UseSafetyEducationLogAttendeesOptions = {
+  enabled?: boolean;
+};
+
+export function useSafetyEducationLogAttendees(
+  siteId: number,
+  logId: number | null,
+  options?: UseSafetyEducationLogAttendeesOptions,
+) {
+  return useQuery<GetSafetyEducationLogAttendeesResponse>({
+    queryKey: ["safety-education-logs", "attendees", siteId, logId],
+    queryFn: () => {
+      if (logId == null) {
+        throw new Error("안전교육일지 ID가 없습니다.");
+      }
+      return getSafetyEducationLogAttendees(siteId, logId);
+    },
+    enabled: (options?.enabled ?? true) && logId != null,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+  });
+}

--- a/src/hooks/use-safety-education-log-employees.ts
+++ b/src/hooks/use-safety-education-log-employees.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getSafetyEducationLogEmployees,
+  type GetSafetyEducationLogEmployeesParams,
+  type GetSafetyEducationLogEmployeesResponse,
+} from "@/lib/api/get-safety-education-log-employees";
+
+type UseSafetyEducationLogEmployeesOptions = {
+  enabled?: boolean;
+};
+
+export function useSafetyEducationLogEmployees(
+  params: GetSafetyEducationLogEmployeesParams,
+  options?: UseSafetyEducationLogEmployeesOptions,
+) {
+  return useQuery<GetSafetyEducationLogEmployeesResponse>({
+    queryKey: ["safety-education-logs", "employees", params.siteId, params.empType],
+    queryFn: () => getSafetyEducationLogEmployees(params),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/src/hooks/use-safety-education-logs.ts
+++ b/src/hooks/use-safety-education-logs.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getSafetyEducationLogs,
+  type GetSafetyEducationLogsParams,
+  type GetSafetyEducationLogsResponse,
+} from "@/lib/api/get-safety-education-logs";
+
+type UseSafetyEducationLogsOptions = {
+  enabled?: boolean;
+};
+
+export function useSafetyEducationLogs(
+  params: GetSafetyEducationLogsParams,
+  options?: UseSafetyEducationLogsOptions,
+) {
+  return useQuery<GetSafetyEducationLogsResponse>({
+    queryKey: ["safety-education-logs", "list", params.siteId, params.year, params.month],
+    queryFn: () => getSafetyEducationLogs(params),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/src/hooks/use-safety-education-reports.ts
+++ b/src/hooks/use-safety-education-reports.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import {
+  getSafetyEducationReports,
+  type GetSafetyEducationReportsParams,
+  type GetSafetyEducationReportsResponse,
+} from "@/lib/api/get-safety-education-reports";
+
+type UseSafetyEducationReportsOptions = {
+  enabled?: boolean;
+};
+
+export function useSafetyEducationReports(
+  params: GetSafetyEducationReportsParams,
+  options?: UseSafetyEducationReportsOptions,
+) {
+  return useQuery<GetSafetyEducationReportsResponse>({
+    queryKey: [
+      "safety-education-reports",
+      "list",
+      params.siteId,
+      params.page,
+      params.size,
+      params.year,
+      params.month,
+    ],
+    queryFn: () => getSafetyEducationReports(params),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    placeholderData: keepPreviousData,
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/src/lib/api/create-safety-education-log.ts
+++ b/src/lib/api/create-safety-education-log.ts
@@ -1,0 +1,45 @@
+export type CreateSafetyEducationLogPayload = {
+  educationType: "REGULAR" | "HIRING" | "WORK_CHANGE" | "SPECIAL" | "OTHER";
+  educationSubject: string;
+  educationContent: string;
+  instructorName: string;
+  educationLocation: string;
+  attendeeEmployeeIds: number[];
+};
+
+export type CreateSafetyEducationLogApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    safetyEducationLogId: number;
+    status: "MANAGER_SIGNING_PENDING" | "MANAGER_SIGNED" | "COMPLETED";
+    pdfUrl: string;
+    attendeeCount: number;
+  };
+};
+
+export async function createSafetyEducationLog(
+  siteId: number,
+  payload: CreateSafetyEducationLogPayload,
+): Promise<NonNullable<CreateSafetyEducationLogApiResponse["data"]>> {
+  const response = await fetch(`/api/v1/${siteId}/safety-education-logs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error("안전교육일지를 생성하는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as CreateSafetyEducationLogApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "안전교육일지를 생성하는 중 오류가 발생했습니다.");
+  }
+
+  return json.data;
+}

--- a/src/lib/api/create-safety-education-report.ts
+++ b/src/lib/api/create-safety-education-report.ts
@@ -1,0 +1,51 @@
+export type SafetyEducationParticipantPayload = {
+  employeeId: number;
+  name: string;
+  employmentType: "REGULAR" | "DAILY";
+};
+
+export type CreateSafetyEducationReportPayload = {
+  educationDate: string;
+  educationType: "REGULAR" | "HIRING" | "WORK_CHANGE" | "SPECIAL" | "OTHER";
+  otherEducationType?: string;
+  educationSubject: string;
+  educationContent: string;
+  instructorName: string;
+  educationLocation: string;
+  participants: SafetyEducationParticipantPayload[];
+};
+
+export type CreateSafetyEducationReportApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    safetyEducationReportId: number;
+    pdfUrl: string;
+  };
+};
+
+export async function createSafetyEducationReport(
+  siteId: number,
+  payload: CreateSafetyEducationReportPayload,
+): Promise<NonNullable<CreateSafetyEducationReportApiResponse["data"]>> {
+  const response = await fetch(`/api/v1/${siteId}/safety-education-reports`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error("안전교육 일지를 생성하는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as CreateSafetyEducationReportApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "안전교육 일지를 생성하는 중 오류가 발생했습니다.");
+  }
+
+  return json.data;
+}

--- a/src/lib/api/get-safety-education-log-attendees.ts
+++ b/src/lib/api/get-safety-education-log-attendees.ts
@@ -1,0 +1,55 @@
+export type SafetyEducationLogAttendee = {
+  employeeId: number;
+  empName: string;
+  empType: "PERMANENT" | "DAILY";
+  isSigned: boolean;
+  signedAt: string | null;
+};
+
+export type GetSafetyEducationLogAttendeesApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    safetyEducationLogId: number;
+    totalCount: number;
+    signedCount: number;
+    unsignedCount: number;
+    attendees: SafetyEducationLogAttendee[];
+  };
+};
+
+export type GetSafetyEducationLogAttendeesResponse = {
+  safetyEducationLogId: number;
+  totalCount: number;
+  signedCount: number;
+  unsignedCount: number;
+  attendees: SafetyEducationLogAttendee[];
+};
+
+export async function getSafetyEducationLogAttendees(
+  siteId: number,
+  logId: number,
+): Promise<GetSafetyEducationLogAttendeesResponse> {
+  const response = await fetch(
+    `/api/v1/${siteId}/safety-education-logs/${logId}/attendees/signature-status`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("참석자 서명 현황을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetSafetyEducationLogAttendeesApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "참석자 서명 현황을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  return json.data;
+}

--- a/src/lib/api/get-safety-education-log-employees.ts
+++ b/src/lib/api/get-safety-education-log-employees.ts
@@ -1,0 +1,66 @@
+export type SafetyEducationLogEmployee = {
+  employeeId: number;
+  empName: string;
+  empType: "PERMANENT" | "DAILY";
+  residentNum: string;
+  hasSafetyEducation: boolean;
+};
+
+export type GetSafetyEducationLogEmployeesApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    items: SafetyEducationLogEmployee[];
+    summary: {
+      totalCount: number;
+      permanentCount: number;
+      dailyCount: number;
+    };
+  };
+};
+
+export type GetSafetyEducationLogEmployeesResponse = {
+  items: SafetyEducationLogEmployee[];
+  summary: {
+    totalCount: number;
+    permanentCount: number;
+    dailyCount: number;
+  };
+};
+
+export type GetSafetyEducationLogEmployeesParams = {
+  siteId: number;
+  empType?: "ALL" | "PERMANENT" | "DAILY";
+};
+
+export async function getSafetyEducationLogEmployees(
+  params: GetSafetyEducationLogEmployeesParams,
+): Promise<GetSafetyEducationLogEmployeesResponse> {
+  const queryParams = new URLSearchParams();
+  if (params.empType && params.empType !== "ALL") {
+    queryParams.set("empType", params.empType);
+  }
+
+  const queryString = queryParams.toString();
+  const url = `/api/v1/${params.siteId}/safety-education-logs/employees${queryString ? `?${queryString}` : ""}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("교육 대상자 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetSafetyEducationLogEmployeesApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "교육 대상자 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  return json.data;
+}

--- a/src/lib/api/get-safety-education-log-pdf.ts
+++ b/src/lib/api/get-safety-education-log-pdf.ts
@@ -1,0 +1,30 @@
+export type GetSafetyEducationLogPdfApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    url: string;
+    expiresAt: string;
+  };
+};
+
+export async function getSafetyEducationLogPdfUrl(siteId: number, logId: number): Promise<string> {
+  const response = await fetch(`/api/documents/safety-education-logs/${logId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("안전교육일지 PDF를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetSafetyEducationLogPdfApiResponse;
+
+  if (!json.success || !json.data?.url) {
+    throw new Error(json.message || "안전교육일지 PDF URL이 응답에 포함되어 있지 않습니다.");
+  }
+
+  return json.data.url;
+}

--- a/src/lib/api/get-safety-education-logs.ts
+++ b/src/lib/api/get-safety-education-logs.ts
@@ -1,0 +1,66 @@
+export type SafetyEducationLogItem = {
+  id: number;
+  educationType: "REGULAR" | "HIRING" | "WORK_CHANGE" | "SPECIAL" | "OTHER";
+  educationSubject: string;
+  instructorName: string;
+  status: "DRAFT" | "MANAGER_SIGNING_PENDING" | "MANAGER_SIGNED" | "COMPLETED";
+  totalAttendeeCount: number;
+  signedAttendeeCount: number;
+  createdAt: string;
+  pdfUrl: string;
+};
+
+export type GetSafetyEducationLogsApiResponse = {
+  success: boolean;
+  message: string;
+  data: SafetyEducationLogItem[];
+};
+
+export type GetSafetyEducationLogsParams = {
+  siteId: number;
+  year?: number;
+  month?: number;
+};
+
+export type GetSafetyEducationLogsResponse = {
+  items: SafetyEducationLogItem[];
+};
+
+export async function getSafetyEducationLogs(
+  params: GetSafetyEducationLogsParams,
+): Promise<GetSafetyEducationLogsResponse> {
+  const queryParams = new URLSearchParams();
+
+  if (params.year) {
+    queryParams.set("year", String(params.year));
+  }
+
+  if (params.month) {
+    queryParams.set("month", String(params.month));
+  }
+
+  const queryString = queryParams.toString();
+  const url = `/api/v1/${params.siteId}/safety-education-logs${queryString ? `?${queryString}` : ""}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("안전교육일지 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetSafetyEducationLogsApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "안전교육일지 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  return {
+    items: json.data,
+  };
+}

--- a/src/lib/api/get-safety-education-report-pdf.ts
+++ b/src/lib/api/get-safety-education-report-pdf.ts
@@ -1,0 +1,33 @@
+export type GetSafetyEducationReportPdfApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    url: string;
+    expiresAt: string;
+  };
+};
+
+export async function getSafetyEducationReportPdfUrl(
+  siteId: number,
+  reportId: number,
+): Promise<string> {
+  const response = await fetch(`/api/documents/safety-education-reports/${reportId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("안전교육 일지 PDF를 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as GetSafetyEducationReportPdfApiResponse;
+
+  if (!json.success || !json.data?.url) {
+    throw new Error(json.message || "안전교육 일지 PDF URL이 응답에 포함되어 있지 않습니다.");
+  }
+
+  return json.data.url;
+}

--- a/src/lib/api/get-safety-education-reports.ts
+++ b/src/lib/api/get-safety-education-reports.ts
@@ -1,0 +1,92 @@
+export type SafetyEducationReportItem = {
+  safetyEducationReportId: number;
+  educationDate: string;
+  writerName: string;
+  participantCount: number;
+  status: "PENDING" | "IN_PROGRESS" | "COMPLETED";
+};
+
+export type SafetyEducationReportsListApiResponse = {
+  success: boolean;
+  message: string;
+  code: string | null;
+  data: {
+    content: SafetyEducationReportItem[];
+    pageNumber: number;
+    pageSize: number;
+    totalElements: number;
+    totalPages: number;
+    first: boolean;
+    last: boolean;
+  };
+};
+
+export type GetSafetyEducationReportsParams = {
+  siteId: number;
+  page?: number;
+  size?: number;
+  year?: number;
+  month?: number;
+};
+
+export type GetSafetyEducationReportsResponse = {
+  items: SafetyEducationReportItem[];
+  pagination: {
+    currentPage: number;
+    pageSize: number;
+    totalElements: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrevious: boolean;
+  };
+};
+
+export async function getSafetyEducationReports(
+  params: GetSafetyEducationReportsParams,
+): Promise<GetSafetyEducationReportsResponse> {
+  const queryParams = new URLSearchParams({
+    page: String((params.page ?? 1) - 1), // API는 0부터 시작
+    size: String(params.size ?? 20),
+  });
+
+  if (params.year) {
+    queryParams.set("year", String(params.year));
+  }
+
+  if (params.month) {
+    queryParams.set("month", String(params.month));
+  }
+
+  const response = await fetch(
+    `/api/v1/${params.siteId}/safety-education-reports?${queryParams.toString()}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("안전교육 일지 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as SafetyEducationReportsListApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "안전교육 일지 목록을 불러오는 중 오류가 발생했습니다.");
+  }
+
+  return {
+    items: json.data.content,
+    pagination: {
+      currentPage: json.data.pageNumber + 1, // 1부터 시작하도록 변환
+      pageSize: json.data.pageSize,
+      totalElements: json.data.totalElements,
+      totalPages: json.data.totalPages,
+      hasNext: !json.data.last,
+      hasPrevious: !json.data.first,
+    },
+  };
+}

--- a/src/lib/api/safety-education-log-signature.ts
+++ b/src/lib/api/safety-education-log-signature.ts
@@ -1,0 +1,100 @@
+import {
+  getSignatureUploadUrl,
+  uploadSignatureToS3,
+  dataURLtoBlob,
+  generateSHA256Hash,
+} from "@/lib/api/contract-signature";
+
+export type SubmitSafetyEducationLogManagerSignaturePayload = {
+  signatureS3Key: string;
+  clientHash: string;
+  coordinates: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    viewWidth: number;
+    viewHeight: number;
+  };
+};
+
+export type SubmitSafetyEducationLogManagerSignatureApiResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    safetyEducationLogId: number;
+    status: "MANAGER_SIGNED" | "COMPLETED";
+    pdfUrl: string;
+    pdfHash: string | null;
+    signedAt: string;
+  };
+};
+
+export async function submitSafetyEducationLogManagerSignature(
+  siteId: number,
+  logId: number,
+  payload: SubmitSafetyEducationLogManagerSignaturePayload,
+): Promise<SubmitSafetyEducationLogManagerSignatureApiResponse["data"]> {
+  const response = await fetch(
+    `/api/v1/${siteId}/safety-education-logs/${logId}/signatures/manager`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify(payload),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("안전교육일지 관리자 서명을 처리하는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as SubmitSafetyEducationLogManagerSignatureApiResponse;
+
+  if (!json.success || !json.data) {
+    throw new Error(json.message || "안전교육일지 관리자 서명 처리에 실패했습니다.");
+  }
+
+  return json.data;
+}
+
+export async function handleSafetyEducationLogManagerSignature(
+  siteId: number,
+  logId: number,
+  signatureDataURL: string,
+): Promise<SubmitSafetyEducationLogManagerSignatureApiResponse["data"]> {
+  // 1. Presigned URL 발급
+  const { uploadUrl, s3Key } = await getSignatureUploadUrl({
+    resourceType: "CONTRACT", // TODO: 안전교육일지용 resourceType이 필요할 수 있음
+    resourceId: String(logId),
+    signerRole: "MANAGER",
+    fileExtension: "png",
+  });
+
+  // 2. 이미지 Blob 변환 및 해시 생성
+  const imageBlob = dataURLtoBlob(signatureDataURL);
+  const clientHash = await generateSHA256Hash(imageBlob);
+
+  // 3. S3에 업로드
+  await uploadSignatureToS3(uploadUrl, imageBlob);
+
+  // 4. 관리자 서명 처리 API 호출
+  // A4 PDF 기본 크기: 595 x 842 포인트
+  // 서명은 일반적으로 하단 중앙에 배치
+  const coordinates = {
+    x: 400, // 서명 시작 X 좌표
+    y: 750, // 서명 시작 Y 좌표 (하단 근처)
+    width: 150, // 서명 너비
+    height: 50, // 서명 높이
+    viewWidth: 595, // PDF 뷰포트 너비 (A4)
+    viewHeight: 842, // PDF 뷰포트 높이 (A4)
+  };
+
+  return await submitSafetyEducationLogManagerSignature(siteId, logId, {
+    signatureS3Key: s3Key,
+    clientHash,
+    coordinates,
+  });
+}

--- a/src/lib/api/safety-education-signature.ts
+++ b/src/lib/api/safety-education-signature.ts
@@ -1,0 +1,74 @@
+import {
+  getSignatureUploadUrl,
+  uploadSignatureToS3,
+  dataURLtoBlob,
+  generateSHA256Hash,
+} from "@/lib/api/contract-signature";
+
+export type SubmitSafetyEducationManagerSignaturePayload = {
+  signatureS3Key: string;
+  clientHash: string;
+};
+
+export type SubmitSafetyEducationManagerSignatureResponse = {
+  success: boolean;
+  message: string;
+  data?: {
+    pdfUrl: string;
+  };
+};
+
+export async function submitSafetyEducationManagerSignature(
+  siteId: number,
+  reportId: number,
+  payload: SubmitSafetyEducationManagerSignaturePayload,
+): Promise<void> {
+  const response = await fetch(
+    `/api/v1/${siteId}/safety-education-reports/${reportId}/signatures/manager`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify(payload),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("안전교육 일지 관리자 서명을 처리하는 중 오류가 발생했습니다.");
+  }
+
+  const json = (await response.json()) as SubmitSafetyEducationManagerSignatureResponse;
+
+  if (!json.success) {
+    throw new Error(json.message || "안전교육 일지 관리자 서명 처리에 실패했습니다.");
+  }
+}
+
+export async function handleSafetyEducationManagerSignature(
+  siteId: number,
+  reportId: number,
+  signatureDataURL: string,
+): Promise<void> {
+  // 1. Presigned URL 발급
+  const { uploadUrl, s3Key } = await getSignatureUploadUrl({
+    resourceType: "CONTRACT", // TODO: 안전교육 일지용 resourceType이 필요할 수 있음
+    resourceId: String(reportId),
+    signerRole: "MANAGER",
+    fileExtension: "png",
+  });
+
+  // 2. 이미지 Blob 변환 및 해시 생성
+  const imageBlob = dataURLtoBlob(signatureDataURL);
+  const clientHash = await generateSHA256Hash(imageBlob);
+
+  // 3. S3에 업로드
+  await uploadSignatureToS3(uploadUrl, imageBlob);
+
+  // 4. 관리자 서명 처리 API 호출
+  await submitSafetyEducationManagerSignature(siteId, reportId, {
+    signatureS3Key: s3Key,
+    clientHash,
+  });
+}


### PR DESCRIPTION
## 🎯 변경 사항

안전교육일지 작성 및 관리 기능을 구현했습니다.

### 주요 기능
- **안전교육일지 목록 조회**: 현장의 안전교육일지 목록을 조회하고 상태별로 필터링
- **안전교육일지 생성 플로우**: 기본 정보 입력 → 교육 대상자 선택 → 관리자 서명
- **관리자 서명 기능**: 서명 좌표 정보를 포함한 관리자 서명 처리
- **교육 대상자 서명 현황**: 참석자별 서명 완료 여부 확인
- **PDF 뷰어 개선**: S3 presigned URL의 CORS 문제를 blob 다운로드 방식으로 해결

### 구현 상세

#### API 유틸리티 함수
- 안전교육일지 목록 조회 (`get-safety-education-logs.ts`)
- 안전교육일지 PDF 조회 (`get-safety-education-log-pdf.ts`)
- 참석자 서명 현황 조회 (`get-safety-education-log-attendees.ts`)
- 교육 대상자 목록 조회 (`get-safety-education-log-employees.ts`)
- 안전교육일지 생성 (`create-safety-education-log.ts`)
- 관리자 서명 처리 (`safety-education-log-signature.ts`) - 좌표 정보 포함

#### TanStack Query 훅
- `useSafetyEducationLogs`: 안전교육일지 목록 조회
- `useSafetyEducationLogAttendees`: 참석자 서명 현황 조회
- `useSafetyEducationLogEmployees`: 교육 대상자 목록 조회
- `useCreateSafetyEducationLog`: 안전교육일지 생성

#### 페이지 컴포넌트
- **목록 페이지** (`/manager/safety-education`): 안전교육일지 목록 및 상태별 조회 버튼
- **생성 페이지** (`/manager/safety-education/create`): 기본 정보 및 교육 정보 입력
- **선택 페이지** (`/manager/safety-education/create/select`): 교육 대상자 선택 (기존 테이블 컴포넌트 재사용)
- **서명 페이지** (`/manager/safety-education/create/sign`): 관리자 서명 및 교육 대상자 서명 현황

#### 개선 사항
- **PDF 뷰어 CORS 문제 해결**: S3 presigned URL을 blob으로 다운로드하여 iframe에서 표시
- **서명 필드 조건부 렌더링**: 관리자 서명 완료 시 서명 필드 숨김
- **상태별 동작 분기**: 서명 대기 상태는 서명 페이지로, 완료 상태는 PDF 모달로 이동
- **모든 근로자 서명 완료 확인**: 모든 근로자 서명 완료 시에만 목록으로 이동

## 📝 사용 방법

### 안전교육일지 작성
1. `/manager/safety-education` 페이지에서 "작성하기" 버튼 클릭
2. 기본 정보 및 교육 정보 입력 후 "다음" 클릭
3. 교육 대상자 선택 후 "다음" 클릭
4. 관리자 서명 입력 후 "서명 저장하기" 클릭
5. 모든 교육 대상자 서명 완료 후 "확인" 버튼 클릭하여 목록으로 이동

### 안전교육일지 조회
1. 목록 페이지에서 안전교육일지 목록 확인
2. 상태별 동작:
   - **관리자 서명 대기** 또는 **관리자 서명 완료**: "보기" 버튼 클릭 시 서명 페이지로 이동
   - **완료**: "보기" 버튼 클릭 시 PDF 모달 열림

### 서명 페이지에서 기존 로그 불러오기
- URL에 `logId` 쿼리 파라미터가 있으면 해당 안전교육일지를 불러와 표시
- 예: `/manager/safety-education/create/sign?logId=1`

## ✅ 테스트

- [x] 안전교육일지 목록 조회 및 표시
- [x] 안전교육일지 생성 플로우 (기본 정보 → 대상자 선택 → 서명)
- [x] 관리자 서명 기능 (서명 좌표 정보 포함)
- [x] 서명 완료 후 서명 필드 숨김 처리
- [x] 교육 대상자 서명 현황 표시
- [x] 모든 근로자 서명 완료 확인 로직
- [x] 상태별 조회 버튼 동작 분기
- [x] PDF 뷰어에서 S3 presigned URL 표시 (CORS 문제 해결)
- [x] 서명 후 서명된 PDF 표시
- [x] 기존 로그 불러오기 (`logId` 쿼리 파라미터)

## 🔗 관련 이슈

- Jira: BU-209
- resolves #86 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 안전교육 생성 워크플로우 추가: 기본정보 입력 → 직원 선택 → 관리자 서명 단계
  * 참석자 선택 화면: 필터, 테이블 선택, 선택 요약(정규직/일용직) 및 선택 검증
  * 관리자용 서명 및 서명 문서 미리보기(PDF) 기능 추가

* **개선 사항**
  * PDF 뷰어 성능 개선: Blob 기반 로딩, 오류 처리 및 재시도 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->