### PR TITLE
[BU-232, #89] fix: 백엔드 v1 버전 정책 반영: /documents, /sites 관련 API 경로 정리

### DIFF
--- a/src/lib/api/get-contract-pdf.ts
+++ b/src/lib/api/get-contract-pdf.ts
@@ -8,7 +8,7 @@ export type GetContractPdfApiResponse = {
 };
 
 export async function getContractPdfUrl(contractId: number): Promise<string> {
-  const response = await fetch(`/api/documents/contracts/${contractId}`, {
+  const response = await fetch(`/api/v1/documents/contracts/${contractId}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/src/lib/api/get-employees.ts
+++ b/src/lib/api/get-employees.ts
@@ -120,13 +120,16 @@ export async function getEmployeeList(
     queryParams.set("name", params.searchKeyword);
   }
 
-  const response = await fetch(`/api/sites/${params.siteId}/employees?${queryParams.toString()}`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
+  const response = await fetch(
+    `/api/v1/sites/${params.siteId}/employees?${queryParams.toString()}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
     },
-    credentials: "include",
-  });
+  );
 
   if (!response.ok) {
     throw new Error("사원 목록을 불러오는 중 오류가 발생했습니다.");
@@ -168,7 +171,7 @@ export async function getEmployeeDetail({
   siteId,
   employeeId,
 }: GetEmployeeDetailParams): Promise<EmployeeDetail> {
-  const response = await fetch(`/api/sites/${siteId}/employees/${employeeId}`, {
+  const response = await fetch(`/api/v1/sites/${siteId}/employees/${employeeId}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -208,7 +211,7 @@ export async function getEmployeeContracts({
   siteId,
   employeeId,
 }: GetEmployeeContractsParams): Promise<GetEmployeeContractsResponse> {
-  const response = await fetch(`/api/sites/${siteId}/employees/${employeeId}/contracts`, {
+  const response = await fetch(`/api/v1/sites/${siteId}/employees/${employeeId}/contracts`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -246,7 +249,7 @@ export async function getEmployeePayslips({
   siteId,
   employeeId,
 }: GetEmployeePayslipsParams): Promise<GetEmployeePayslipsResponse> {
-  const response = await fetch(`/api/sites/${siteId}/employees/${employeeId}/payslips`, {
+  const response = await fetch(`/api/v1/sites/${siteId}/employees/${employeeId}/payslips`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -281,7 +284,7 @@ export async function getEmployeePayslips({
 }
 
 export async function getContractPdfUrl(contractId: number): Promise<string> {
-  const response = await fetch(`/api/documents/contracts/${contractId}`, {
+  const response = await fetch(`/api/v1/documents/contracts/${contractId}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -303,7 +306,7 @@ export async function getContractPdfUrl(contractId: number): Promise<string> {
 }
 
 export async function getPayslipPdfUrl(payrollId: number): Promise<string> {
-  const response = await fetch(`/api/documents/payslips/${payrollId}`, {
+  const response = await fetch(`/api/v1/documents/payslips/${payrollId}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/src/lib/api/get-safety-education-log-pdf.ts
+++ b/src/lib/api/get-safety-education-log-pdf.ts
@@ -8,7 +8,7 @@ export type GetSafetyEducationLogPdfApiResponse = {
 };
 
 export async function getSafetyEducationLogPdfUrl(siteId: number, logId: number): Promise<string> {
-  const response = await fetch(`/api/documents/safety-education-logs/${logId}`, {
+  const response = await fetch(`/api/v1/documents/safety-education-logs/${logId}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/src/lib/api/get-safety-education-report-pdf.ts
+++ b/src/lib/api/get-safety-education-report-pdf.ts
@@ -11,7 +11,7 @@ export async function getSafetyEducationReportPdfUrl(
   siteId: number,
   reportId: number,
 ): Promise<string> {
-  const response = await fetch(`/api/documents/safety-education-reports/${reportId}`, {
+  const response = await fetch(`/api/v1/documents/safety-education-reports/${reportId}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/src/lib/api/get-safety-work-records.ts
+++ b/src/lib/api/get-safety-work-records.ts
@@ -13,7 +13,7 @@ export type {
 } from "@/types/safety-work";
 
 export async function getSafetyEducationLogPdfUrl(siteId: number, logId: number): Promise<string> {
-  const response = await fetch(`/api/documents/safety-education-logs/${logId}`, {
+  const response = await fetch(`/api/v1/documents/safety-education-logs/${logId}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -35,7 +35,7 @@ export async function getSafetyEducationLogPdfUrl(siteId: number, logId: number)
 }
 
 export async function getWorkReportPdfUrl(siteId: number, workReportId: number): Promise<string> {
-  const response = await fetch(`/api/documents/work-reports/${workReportId}`, {
+  const response = await fetch(`/api/v1/documents/work-reports/${workReportId}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## 🎯 변경 사항

- 백엔드 API 버전 정책(`/api/v1`)에 맞추어 프론트엔드 문서/사이트 관련 API 경로를 정리했습니다.
  - `/api/sites/...` → `/api/v1/sites/...`
  - `/api/documents/...` → `/api/v1/documents/...`
- 문서(PDF) URL에 대해 이전에 적용했던 `/api/v1/documents/` → `/api/documents/` 문자열 치환 핫픽스를 제거하고,
  백엔드의 `/api/v1/documents/...` 응답을 그대로 사용하는 구조로 정리했습니다.

## 📝 사용 방법

- Vercel / 로컬 환경에서 아래 경로들을 통해 동작을 확인할 수 있습니다.
  - 현장 관리자 로그인 → `근로계약서 관리` 페이지
    - 근로계약서 테이블에서 **열람 버튼** 클릭 시, `/api/v1/documents/contracts/:id`를 통해 PDF가 정상 열리는지 확인
  - 사원 상세 문서 탭
    - 근로계약서 / 급여명세서 열람 시 `/api/v1/documents/contracts/:id`, `/api/v1/documents/payslips/:id` 호출 여부 확인
  - 안전/작업 문서 관련 페이지
    - 안전교육 일지 / 안전교육 보고서 / 작업일보 PDF 열람 시
      - `/api/v1/documents/safety-education-logs/:id`
      - `/api/v1/documents/safety-education-reports/:id`
      - `/api/v1/documents/work-reports/:id`
      로 요청이 나가는지 및 정상 응답 여부 확인

## ✅ 테스트

- [x] 현장 관리자 근로계약서 목록에서 **열람** 버튼 클릭 시 404 없이 PDF가 정상 노출된다.
- [x] 사원 상세 > 근로계약서 / 급여명세서 문서 열람 시 PDF가 정상 노출된다.
- [x] 안전교육 일지 / 안전교육 보고서 / 작업일보 PDF 열람이 모두 정상 동작한다.
- [x] 네트워크 탭에서 관련 호출이 모두 `/api/v1/...` 형태로 이루어지는 것을 확인했다.
- [ ] 로컬 및 Vercel 배포 환경 모두에서 동일한 동작을 확인했다.

## 🔗 관련 이슈

- Jira: resolves BU-232
- resolves #89 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **유지보수**
  * API 엔드포인트가 최신 버전으로 업데이트되었습니다.
  * 직원 정보, 계약 문서, 안전 교육 기록 관련 시스템 인프라가 개선되었습니다.
  * 보안 및 안정성이 강화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->