### PR TITLE
[BU-233, #91] fix: 현장 관리자 근로계약서 작성 모달이 가려지는 문제 수정

### DIFF
--- a/src/components/features/manager/contracts/manager-contract-create-type-modal.tsx
+++ b/src/components/features/manager/contracts/manager-contract-create-type-modal.tsx
@@ -24,6 +24,7 @@ export function ManagerContractCreateTypeModal({
       footer={null}
       centered
       width={520}
+      zIndex={2000}
       classNames={{
         content: "bg-white",
         body: "p-6",


### PR DESCRIPTION
## 🎯 변경 사항

- 현장 관리자 근로계약서 관리 페이지에서 **근로계약서 유형 선택 모달**이 배포 환경에서 가려질 수 있던 문제를 방지하기 위해,
  `ManagerContractCreateTypeModal` 의 `zIndex` 를 2000으로 올려 상세보기 모달과 동일 레벨에서 노출되도록 조정했습니다.

## 📝 사용 방법

- Vercel Preview 배포 URL 접속 후, 아래 플로우로 기능을 확인할 수 있습니다.
  1. **현장 관리자 로그인**
  2. 사이드바에서 **근로계약서 관리** (`/manager/contracts`) 메뉴 진입
  3. **미작성 근로자(상태 Pill: "미작성", contractId: null)** 의 **"작성" 버튼** 클릭
     - 근로계약서 유형 선택 모달(상용직/일용직)이 정상적으로 노출되어야 합니다.
  4. 모달에서 유형 선택 후, `/manager/contracts/create?empType=...` 로 이동되는지 확인
  5. 이미 작성/서명 완료된 근로자의 **"열람" 버튼** 클릭 시,
     - 브라우저 네트워크 탭에서 아래 경로 요청이 성공하는지 확인
       - `/api/v1/documents/contracts/:id`
  6. 안전/작업 문서 관련 페이지에서 PDF 열람 시에도 아래 경로로 요청되는지 확인
     - `/api/v1/documents/safety-education-logs/:id`
     - `/api/v1/documents/safety-education-reports/:id`
     - `/api/v1/documents/work-reports/:id`

## ✅ 테스트

- [ ] `/manager/contracts` 진입 시 계약 목록이 정상 로딩되고, dev/prod 모두 같은 데이터 형태(특히 `empType`, `contractId`)로 보인다.
- [ ] 미작성 근로자의 **"작성" 버튼** 클릭 시 근로계약서 유형 선택 모달이 **dev / Vercel preview 모두에서** 노출된다.
- [ ] 유형 선택 후 `/manager/contracts/create?empType=...` 로 라우팅이 정상 동작한다.
- [ ] 위 기능들을 수행할 때 브라우저 콘솔에 에러(빨간 로그)가 발생하지 않는다.

## 🔗 관련 이슈

- Jira: resolves BU-232
- resolves #91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 계약 관리자 모달이 다른 UI 요소 위에 올바르게 표시되도록 모달 레이어링을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->